### PR TITLE
Improve error prints for failed parsing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,17 +48,6 @@ mod tests {
             Ok(parsed) => println!("Parsing successful: {:?}", parsed),
             Err(err) => {
                 eprintln!("Parsing failed: {}", err);
-                
-                // Extract error location and line-column details
-                if let pest::error::LineColLocation::Span(start, end) = err.line_col {
-                    eprintln!(
-                        "Error spans from line {}, column {} to line {}, column {}",
-                        start.0, start.1, end.0, end.1
-                    );
-                } else if let pest::error::LineColLocation::Pos((line, col)) = err.line_col {
-                    eprintln!("Error occurred at line {}, column {}", line, col);
-                }
-
                 panic!("failed to parse");
             }
 


### PR DESCRIPTION
**Is there a more elegant way?**

## Proof (Debug output):
Wrap your pairs in `DisplayPair()` to get output like:
```
 file
  - fun
    - id: "add"
    - arglist
      - arg
        - id: "a"
        - tpe: "u32"
      - arglist
        - arg
          - id: "b"
          - tpe: "u32"
        - arglist
          - arg
            - id: "s"
            - tpe: "u32"
    - assign
      - path_id: "dut.a"
      - expr
        - path_id: "a"
    - assign
      - path_id: "dut.b"
      - expr
        - path_id: "b"
    - cmd
      - path_id: "step"
    - cmd
      - path_id: "fork"
    - assign
      - path_id: "dut.a"
      - expr
        - path_id: "X"
    - assign
      - path_id: "dut.b"
      - expr
        - path_id: "X"
    - assign
      - path_id: "s"
      - expr
        - path_id: "dut.s"
  - EOI: ""
```

## Proof (Error output):

Performing this in `add.prot`
```
-  dut.b := X;
+  dut.b := X:
```

causes this error output on `cargo test`:

```
running 4 tests
test tests::test_add_prot ... FAILED
test tests::test_calyx_go_done_prot ... ok
test tests::test_cond_prot ... ok
test tests::test_mul_prot ... ok

failures:

---- tests::test_add_prot stdout ----
Parsing failed:  --> 7:13
  |
7 |   dut.b := X:
  |             ^---
  |
  = expected neq, leq, eq, add, log_and, log_or, subtract, multiply, divide, mod, shift_left, or shift_right
thread 'tests::test_add_prot' panicked at src/lib.rs:62:17:
failed to parse
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    tests::test_add_prot

test result: FAILED. 3 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```