### PR TITLE
add aes example transactions

### DIFF
--- a/tests/aes128.prot
+++ b/tests/aes128.prot
@@ -1,0 +1,19 @@
+// src: https://github.com/ekiwi/paso/blob/ad2bf83f420ca704ff0e76e7a583791a0e80a545/benchmarks/src/benchmarks/aes/TinyAESSpec.scala#L220
+
+struct TinyAES128 {
+  in key: u128,
+  in state: u128,
+  out output: u128,
+}
+
+fn aes128<dut : TinyAES128>(in key: u128, in state: u128, out output: u128) {
+  dut.state := state;
+  dut.key := key;
+  step();
+  fork();
+  dut.state := X;
+  dut.key := X;
+  // twenty cycles to complete
+  step(20);
+  assert_eq(dut.output, output);
+}

--- a/tests/aes128_expand_key.prot
+++ b/tests/aes128_expand_key.prot
@@ -1,0 +1,17 @@
+// src: https://github.com/ekiwi/paso/blob/ad2bf83f420ca704ff0e76e7a583791a0e80a545/benchmarks/src/benchmarks/aes/TinyAESSpec.scala#L179
+
+struct ExpandKey128 {
+  in input: u128,
+  out output: u128,
+  out output_delayed: u128,
+}
+
+fn aes128<dut : ExpandKey128>(in input: u128, out output: u128) {
+  dut.input := input;
+  step();
+  fork();
+  dut.input := X;
+  assert_eq(dut.output, output);
+  step();
+  assert_eq(dut.output_delayed, output);
+}

--- a/tests/aes128_round.prot
+++ b/tests/aes128_round.prot
@@ -1,0 +1,18 @@
+// src: https://github.com/ekiwi/paso/blob/ad2bf83f420ca704ff0e76e7a583791a0e80a545/benchmarks/src/benchmarks/aes/TinyAESSpec.scala#L164
+
+struct RoundIO {
+  in state: u128,
+  in key: u128,
+  out state_next: u128,
+}
+
+fn aes128<dut : RoundIO>(in key: u128, in state: u128, out output: u128) {
+  dut.state := state;
+  step();
+  fork();
+  dut.state := X;
+  dut.key := key;
+  step();
+  dut.key := X;
+  assert_eq(dut.state_next, output);
+}


### PR DESCRIPTION
Some example transaction protocols for the TinyAES Verilog implementation.