### PR TITLE
Every Transaction Forks Exactly Once

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -640,6 +640,9 @@ pub fn parse_file(
                 return Err(e);
             }
 
+            // implicit fork at the end of every transaction
+            context.tr.s(Stmt::Fork);
+
             trs.push((context.st.clone(), context.tr.clone()));
         }
     }


### PR DESCRIPTION
two options:
1. implement this by placing a fork explicitly in the IR of each transaction during parsing 
2. when the scheduler reaches the end of a transaction (next statement map returns `None`), it schedules the next TODO (if it exists)

I implemented option 1 for now (bc its a 1 line change), but i'm not sure if 2 is better

**TODO:** instead of this, we should check with a flag if a thread has already forked, if it has it cannot fork again (dynamic check), if it doesn't fork upon completion perform an extra fork 