### PR TITLE
Add Clippy to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,3 +49,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: cargo fmt --check
+      
+  clippy:
+    name: Run Clippy
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - run: cargo clippy --all-targets --all-features -- -D warnings


### PR DESCRIPTION
should be merged after #56 

"Just make sure that the rust version in CI is fixed as new Rust versions will add new clippy errors." -- not sure what this means / if i did it right?

