### PR TITLE
Allow Empty Blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 Cargo.lock
 .idea/
 test_run/
-/tests/snapshots
 *.btor

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -329,7 +329,7 @@ impl<'a> Evaluator<'a> {
             }
             Stmt::Block(stmt_ids) => {
                 if stmt_ids.is_empty() {
-                    return Ok(self.next_stmt_map[stmt_id]);
+                    Ok(self.next_stmt_map[stmt_id])
                 } else {
                     Ok(Some(stmt_ids[0]))
                 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -329,7 +329,7 @@ impl<'a> Evaluator<'a> {
             }
             Stmt::Block(stmt_ids) => {
                 if stmt_ids.is_empty() {
-                    Ok(None)
+                    return Ok(self.next_stmt_map[stmt_id]);
                 } else {
                     Ok(Some(stmt_ids[0]))
                 }

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -128,8 +128,7 @@ impl Transaction {
                     _ => {}
                 }
             }
-        }
-        else {
+        } else {
             panic!("Precondition: input StmtId refers to the a Stmt::Block variant was violated.");
         }
 

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -94,6 +94,11 @@ impl Transaction {
         let mut map = FxHashMap::default();
 
         if let Stmt::Block(stmts) = &self.stmts[block_id] {
+            // Handle empty blocks by mapping them directly to stmt_after_block
+            if stmts.is_empty() {
+                map.insert(block_id, stmt_after_block);
+            }
+
             for (i, &stmt_id) in stmts.iter().enumerate() {
                 let mut new_stmt_after_block = stmt_after_block;
                 if i == stmts.len() - 1 {
@@ -123,6 +128,9 @@ impl Transaction {
                     _ => {}
                 }
             }
+        }
+        else {
+            panic!("Precondition: input StmtId refers to the a Stmt::Block variant was violated.");
         }
 
         map

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,6 +4,7 @@
 // author: Kevin Laeufer <laeufer@cornell.edu>
 // author: Francis Pham <fdp25@cornell.edu>
 
+use crate::ir::Stmt;
 use baa::BitVecValue;
 use pest::error::InputLocation;
 use pest::iterators::Pairs;
@@ -428,9 +429,14 @@ impl ParserContext<'_> {
         )?;
         let expr_id = self.parse_expr(expr_rule.into_inner())?;
         let if_block = self.parse_stmt_block(inner_if)?;
-        let else_rule = self.expect_rule(inner_rules.next(), &pair, "Expected else block")?;
-        let inner_else = else_rule.into_inner();
-        let else_block = self.parse_stmt_block(inner_else)?;
+
+        // Parse the optional else block
+        let else_block = inner_rules
+            .next()
+            .map(|else_rule| self.parse_stmt_block(else_rule.into_inner()))
+            .transpose()?
+            .unwrap_or_else(|| self.tr.s(Stmt::Block(vec![])));
+
         Ok(Stmt::IfElse(expr_id, if_block, else_block))
     }
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -819,4 +819,40 @@ pub mod tests {
         let results = scheduler.execute_threads();
         assert!(results[0].is_err());
     }
+
+    #[test]
+    fn test_empty() {
+        // vacuous test where the protocol has no statements in it (just an empty block)
+        // all results should always be ok, regardless of inputs.
+        let handler = &mut DiagnosticHandler::new();
+        let transaction_filename = "tests/identities/empty.prot";
+        let verilog_path = "examples/identity/identity_d0.v";
+        let (ctx, sys) = create_sim_context(verilog_path);
+        let sim = &mut patronus::sim::Interpreter::new(&ctx, &sys);
+
+        let parsed_data: Vec<(Transaction, SymbolTable)> =
+            parsing_helper(transaction_filename, handler);
+        let irs: Vec<(&Transaction, &SymbolTable)> =
+            parsed_data.iter().map(|(tr, st)| (tr, st)).collect();
+
+        let todos: Vec<(usize, Vec<BitVecValue>)> = vec![(
+            0,
+            vec![BitVecValue::from_u64(0, 32), BitVecValue::from_u64(1, 32)],
+            
+        ),
+        (
+            0,
+            vec![BitVecValue::from_u64(1, 32), BitVecValue::from_u64(1, 32)],
+        ),
+        (
+            0,
+            vec![BitVecValue::from_u64(0, 32), BitVecValue::from_u64(1, 32)],
+        )];
+
+        let mut scheduler = Scheduler::new(irs.clone(), todos.clone(), &ctx, &sys, sim, handler);
+        let results: Vec<Result<(), String>> = scheduler.execute_threads();
+        assert!(results[0].is_ok());
+        assert!(results[1].is_ok());
+        assert!(results[2].is_ok());
+    }
 }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -835,19 +835,20 @@ pub mod tests {
         let irs: Vec<(&Transaction, &SymbolTable)> =
             parsed_data.iter().map(|(tr, st)| (tr, st)).collect();
 
-        let todos: Vec<(usize, Vec<BitVecValue>)> = vec![(
-            0,
-            vec![BitVecValue::from_u64(0, 32), BitVecValue::from_u64(1, 32)],
-            
-        ),
-        (
-            0,
-            vec![BitVecValue::from_u64(1, 32), BitVecValue::from_u64(1, 32)],
-        ),
-        (
-            0,
-            vec![BitVecValue::from_u64(0, 32), BitVecValue::from_u64(1, 32)],
-        )];
+        let todos: Vec<(usize, Vec<BitVecValue>)> = vec![
+            (
+                0,
+                vec![BitVecValue::from_u64(0, 32), BitVecValue::from_u64(1, 32)],
+            ),
+            (
+                0,
+                vec![BitVecValue::from_u64(1, 32), BitVecValue::from_u64(1, 32)],
+            ),
+            (
+                0,
+                vec![BitVecValue::from_u64(0, 32), BitVecValue::from_u64(1, 32)],
+            ),
+        ];
 
         let mut scheduler = Scheduler::new(irs.clone(), todos.clone(), &ctx, &sys, sim, handler);
         let results: Vec<Result<(), String>> = scheduler.execute_threads();

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -315,6 +315,11 @@ pub mod tests {
     }
 
     #[test]
+    fn test_simple_if_without_else_transaction() {
+        test_helper("tests/if_without_else.prot", "if_without_else");
+    }
+
+    #[test]
     fn serialize_easycond_transaction() {
         // Manually create the expected result of parsing `easycond.prot`.
         // Note that the order in which things are created will be different in the parser.

--- a/tests/identities/dual_identity_d1.prot
+++ b/tests/identities/dual_identity_d1.prot
@@ -37,11 +37,7 @@ fn two<dut: DualIdentity>(in a: u64, in b: u64) {
     if (dut.b == b) {
         dut.a := a;
     }
-    else {
-        // TODO: this is a placeholder statement because currently 
-        // the scheduler cannot handle empty else blocks
-        assert_eq(1, 1);
-    }
+    else {}
 
     step();
 

--- a/tests/identities/dual_identity_d1.prot
+++ b/tests/identities/dual_identity_d1.prot
@@ -37,11 +37,9 @@ fn two<dut: DualIdentity>(in a: u64, in b: u64) {
     if (dut.b == b) {
         dut.a := a;
     }
-    else {}
-
+    
     step();
 
     assert_eq(dut.s1, a);
     assert_eq(dut.s2, b);
 }
-

--- a/tests/identities/empty.prot
+++ b/tests/identities/empty.prot
@@ -1,0 +1,7 @@
+struct Identity {
+  in a: u32,
+  out s: u32,
+}
+
+// the empty protocol. Does nothing, always results in an Ok() Result variant
+fn empty<DUT: Identity>(in a: u32, out s: u32) {}

--- a/tests/if_without_else.prot
+++ b/tests/if_without_else.prot
@@ -1,0 +1,10 @@
+struct DualIdentity {
+  in a: u64,
+  in b: u64,
+}
+
+fn if_without_else<dut: DualIdentity>(in a: u64, in b: u64) {
+    if (dut.b == b) {
+        dut.a := a;
+    }
+}

--- a/tests/snapshots/protocols__serialize__tests__if_without_else.snap
+++ b/tests/snapshots/protocols__serialize__tests__if_without_else.snap
@@ -1,0 +1,15 @@
+---
+source: src/serialize.rs
+expression: content
+---
+struct DualIdentity {
+  in a: u64,
+  in b: u64,
+}
+
+fn if_without_else<dut: DualIdentity>(in a: u64, in b: u64) {
+  if dut.b == b {
+    dut.a := a;
+  } else {
+  }
+}


### PR DESCRIPTION
We are trying to address #52 to allow if statements without a corresponding else block. the solution is to make that just syntactic sugar for an if followed by an empty block.

### Change parser to allow if-only statements and parse into de-sugared version.
The grammar currently allows for an if-only statement, but the parser expects an else. Here's the fix:
```rust
-        let else_rule = self.expect_rule(inner_rules.next(), &pair, "Expected else block")?;
-        let inner_else = else_rule.into_inner();
-        let else_block = self.parse_stmt_block(inner_else)?;
+
+        // Parse the optional else block
+        let else_block = inner_rules
+            .next()
+            .map(|else_rule| self.parse_stmt_block(else_rule.into_inner()))
+            .transpose()?
+            .unwrap_or_else(|| self.tr.s(Stmt::Block(vec![])));
         Ok(Stmt::IfElse(expr_id, if_block, else_block))
```

Testing: 
`test_simple_if_without_else_transaction`:This is just a basic serialization transaction, where we have an if-only input, and expect a snapshot output that has the identical if followed by an empty else block. 
**Input:**
```
fn if_without_else<dut: DualIdentity>(in a: u64, in b: u64) {
    if (dut.b == b) {
        dut.a := a;
    }
}
```
**Output:**
```
fn if_without_else<dut: DualIdentity>(in a: u64, in b: u64) {
  if dut.b == b {
    dut.a := a;
  } else {
  }
}
```

### Allowing for empty blocks
Step 1 is allowing for empty blocks in the first place; they are allowed in the grammar, but previously, an empty block was not handled properly by the scheduler due to an error in how the next statement mapping was generated and used by the interpreter. This is fixed in this PR.

Testing: The functionality is tests in two separate ways. First `test_scheduler_dual_identity` has a test case in which we have an if-only block which failed prior to this change. I also created a very simple empty protocol with a corresponding combinational logic identity function circuit, which should always pass. 
