### PR TITLE
Update pretty-printer for scheduler logs to use existing serializer

### DIFF
--- a/protocols/src/ir.rs
+++ b/protocols/src/ir.rs
@@ -10,6 +10,8 @@ use cranelift_entity::{PrimaryMap, SecondaryMap, entity_impl};
 use rustc_hash::FxHashMap;
 use std::ops::Index;
 
+use crate::serialize::serialize_expr;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Transaction {
     pub name: String,
@@ -151,25 +153,7 @@ impl Transaction {
     /// Pretty-prints an `Expr` based on its `ExprId`, using the
     /// provided `SymbolTable` to look up `SymbolId`s
     pub fn format_expr(&self, expr_id: &ExprId, symbol_table: &SymbolTable) -> String {
-        let expr = &self[expr_id];
-        match expr {
-            Expr::Const(bit_vec_value) => format!("{:#?}", bit_vec_value),
-            Expr::Sym(symbol_id) => symbol_table[symbol_id].full_name(symbol_table),
-            Expr::DontCare => "X".to_string(),
-            Expr::Binary(bin_op, expr_id1, expr_id2) => {
-                let e1 = self.format_expr(expr_id1, symbol_table);
-                let e2 = self.format_expr(expr_id2, symbol_table);
-                format!("{} {} {}", bin_op, e1, e2)
-            }
-            Expr::Unary(unary_op, expr_id) => {
-                let e = self.format_expr(expr_id, symbol_table);
-                format!("{}{}", unary_op, e)
-            }
-            Expr::Slice(expr_id, i, j) => {
-                let e = self.format_expr(expr_id, symbol_table);
-                format!("{}[{}:{}]", e, i, j)
-            }
-        }
+        serialize_expr(self, symbol_table, expr_id)
     }
 
     /// Pretty-prints a `Statement` based on its `StmtId`

--- a/protocols/src/ir.rs
+++ b/protocols/src/ir.rs
@@ -5,7 +5,7 @@
 // author: Francis Pham <fdp25@cornell.edu>
 
 use baa::BitVecValue;
-use cranelift_entity::{entity_impl, PrimaryMap, SecondaryMap};
+use cranelift_entity::{PrimaryMap, SecondaryMap, entity_impl};
 use rustc_hash::FxHashMap;
 use std::ops::Index;
 

--- a/protocols/src/serialize.rs
+++ b/protocols/src/serialize.rs
@@ -8,6 +8,7 @@ use crate::ir::*;
 use baa::BitVecOps;
 use std::io::Write;
 
+/// Serializes a `Vec` of `(SymbolTable, Transaction)` pairs to a `String`
 pub fn serialize_to_string(trs: Vec<(SymbolTable, Transaction)>) -> std::io::Result<String> {
     let mut out = Vec::new();
     serialize(&mut out, trs)?;
@@ -15,6 +16,7 @@ pub fn serialize_to_string(trs: Vec<(SymbolTable, Transaction)>) -> std::io::Res
     Ok(out)
 }
 
+/// Pretty prints a `type` with respect to the current `SymbolTable`
 fn serialize_type(st: &SymbolTable, tpe: Type) -> String {
     match tpe {
         Type::BitVec(t) => "u".to_owned() + &t.to_string(),
@@ -23,42 +25,65 @@ fn serialize_type(st: &SymbolTable, tpe: Type) -> String {
     }
 }
 
-fn serialize_dir(dir: Dir) -> String {
-    match dir {
-        Dir::In => "in".to_string(),
-        Dir::Out => "out".to_string(),
+/// Pretty prints a `Direction`
+impl std::fmt::Display for Dir {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Dir::In => write!(f, "in"),
+            Dir::Out => write!(f, "out"),
+        }
     }
 }
 
+/// Pretty-printer for `BinaryOp`s
+impl std::fmt::Display for BinOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BinOp::Equal => write!(f, "=="),
+            BinOp::Concat => write!(f, "+"),
+        }
+    }
+}
+
+/// Pretty-printer for `UnaryOp`s
+impl std::fmt::Display for UnaryOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "!")
+    }
+}
+
+/// Pretty-prints an `Expression` (identified by its `ExprId`) using the current
+/// `Transaction` and `SymbolTable`
 pub fn serialize_expr(tr: &Transaction, st: &SymbolTable, expr_id: &ExprId) -> String {
     match &tr[expr_id] {
         Expr::Const(val) => val.to_u64().unwrap().to_string(),
         Expr::Sym(symid) => st[symid].full_name(st),
-        Expr::DontCare => "X".to_owned(),
-        Expr::Unary(UnaryOp::Not, not_exprid) => {
-            "!(".to_owned() + &serialize_expr(tr, st, not_exprid) + ")"
+        Expr::DontCare => "X".to_string(),
+        Expr::Unary(unary_op, expr_id) => {
+            let e = serialize_expr(tr, st, expr_id);
+            format!("{}({})", unary_op, e)
         }
-        Expr::Binary(BinOp::Concat, lhs, rhs) => {
-            serialize_expr(tr, st, lhs) + " + " + &serialize_expr(tr, st, rhs)
-        }
-        Expr::Binary(BinOp::Equal, lhs, rhs) => {
-            serialize_expr(tr, st, lhs) + " == " + &serialize_expr(tr, st, rhs)
+        Expr::Binary(op, lhs, rhs) => {
+            let e1 = serialize_expr(tr, st, lhs);
+            let e2 = serialize_expr(tr, st, rhs);
+            format!("{e1} {op} {e2}")
         }
         Expr::Slice(expr, idx1, idx2) => {
+            let e = serialize_expr(tr, st, expr);
+            let i = idx1.to_string();
             if *idx2 == *idx1 {
-                serialize_expr(tr, st, expr) + "[" + idx1.to_string().as_str() + "]"
+                format!("{}[{}]", e, i)
             } else {
-                serialize_expr(tr, st, expr)
-                    + "["
-                    + idx1.to_string().as_str()
-                    + ":"
-                    + idx2.to_string().as_str()
-                    + "]"
+                let j = idx2.to_string();
+                format!("{}[{}:{}]", e, i, j)
             }
         }
     }
 }
 
+/// Pretty-prints a `Statement` (identified by its `StmtId`) using the
+/// provided `Transaction` and `SymbolTable` using the provided output buffer `out`,
+/// with the amount of indentation specified by `index`
 pub fn build_statements(
     out: &mut impl Write,
     tr: &Transaction,
@@ -117,6 +142,8 @@ pub fn build_statements(
     Ok(())
 }
 
+/// Pretty prints the definition of a struct type definition
+/// to the output buffer `out`
 pub fn serialize_structs(
     out: &mut impl Write,
     st: &SymbolTable,
@@ -129,7 +156,7 @@ pub fn serialize_structs(
             writeln!(
                 out,
                 "  {} {}: {},",
-                serialize_dir(field.dir()),
+                field.dir(),
                 field.name(),
                 serialize_type(st, field.tpe())
             )?;
@@ -140,6 +167,8 @@ pub fn serialize_structs(
     Ok(())
 }
 
+/// Serializes a `Vec` of `(SymbolTable, Transaction)` pairs to the provided
+/// output buffer `out`
 pub fn serialize(
     out: &mut impl Write,
     trs: Vec<(SymbolTable, Transaction)>,
@@ -174,7 +203,7 @@ pub fn serialize(
                     writeln!(
                         out,
                         "{} {}: {}) {{",
-                        serialize_dir(arg.dir()),
+                        arg.dir(),
                         st[arg].name(),
                         serialize_type(&st, st[arg].tpe())
                     )?;
@@ -182,7 +211,7 @@ pub fn serialize(
                     write!(
                         out,
                         "{} {}: {}, ",
-                        serialize_dir(arg.dir()),
+                        arg.dir(),
                         st[arg].name(),
                         serialize_type(&st, st[arg].tpe())
                     )?;

--- a/protocols/src/serialize.rs
+++ b/protocols/src/serialize.rs
@@ -79,12 +79,7 @@ pub fn build_statements(
             st[lhs].full_name(st),
             serialize_expr(tr, st, rhs)
         )?,
-        Stmt::Step => writeln!(
-            out,
-            "{}step();",
-            "  ".repeat(index),
-            // serialize_expr(tr, st, expr_id)
-        )?,
+        Stmt::Step => writeln!(out, "{}step();", "  ".repeat(index),)?,
         Stmt::Fork => writeln!(out, "{}fork();", "  ".repeat(index))?,
         Stmt::While(cond, bodyid) => {
             writeln!(
@@ -125,12 +120,12 @@ pub fn build_statements(
 pub fn serialize_structs(
     out: &mut impl Write,
     st: &SymbolTable,
-    strct_ids: Vec<StructId>,
+    struct_ids: Vec<StructId>,
 ) -> std::io::Result<()> {
-    for strct_id in strct_ids {
-        writeln!(out, "struct {} {{", st[strct_id].name())?;
+    for struct_id in struct_ids {
+        writeln!(out, "struct {} {{", st[struct_id].name())?;
 
-        for field in st[strct_id].pins() {
+        for field in st[struct_id].pins() {
             writeln!(
                 out,
                 "  {} {}: {},",


### PR DESCRIPTION
Updates the pretty-printer for statements/expressions in scheduler logs (#86) to use the existing functions in `serializer.rs`.

I've also rewritten some functions in `serializer.rs` to be a bit more idiomatic (e.g. implement `Display` trait where applicable). 