### PR TITLE
Add checks for `ForkBeforeStep` + `DoubleFork` errors (+ docs on well-formedness)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Options:
   -m, --module <MODULE_NAME>
           Name of the top-level module (if one exists)
   -f, --fst <WAVEFORM_FILE>
-          Name of the waveform file (.fst) in which to save results [default: trace.fst]
+          (Optional) Name of the waveform file (.fst) in which to save results
   -v, --verbose...
           Prints logs / debugging information to stdout
   -h, --help

--- a/interp/src/main.rs
+++ b/interp/src/main.rs
@@ -33,16 +33,16 @@ struct Cli {
     #[arg(short, long, value_name = "MODULE_NAME")]
     module: Option<String>,
 
-    /// Name of the waveform file (.fst) in which to save results
-    #[arg(short, long, value_name = "WAVEFORM_FILE", default_value = "trace.fst")]
-    fst: String,
+    /// (Optional) Name of the waveform file (.fst) in which to save results
+    #[arg(short, long, value_name = "WAVEFORM_FILE")]
+    fst: Option<String>,
 
     /// Users can specify `-v` or `--verbose` to toggle logging
     #[command(flatten)]
     verbosity: Verbosity<WarnLevel>,
 
-    /// To suppress colors in error messages, pass in `--color never`
-    /// Otherwise, by default, error messages are displayed w/ ANSI colors
+    /// Pass in `--color never` to suppress colored error messages.       
+    /// (By default, error messages are displayed w/ ANSI colors.)
     #[arg(long, value_name = "COLOR_CHOICE", default_value = "auto")]
     color: ColorChoice,
 
@@ -50,7 +50,8 @@ struct Cli {
     #[arg(short, long, value_name = "ERROR_LOCATIONS")]
     no_error_locations: bool,
 
-    /// Stop the interpreter if it ever reaches the maximum number if cycles specified with this option.
+    /// Stop the interpreter if it ever reaches the maximum number
+    /// of cycles specified with this option.
     #[arg(long)]
     max_steps: Option<u32>,
 }
@@ -106,7 +107,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     // Run the interpreter and the scheduler on the parsed transaction file
-    let interpreter = patronus::sim::Interpreter::new_with_wavedump(&ctx, &sys, cli.fst);
+    let interpreter = if let Some(waveform_file) = cli.fst {
+        patronus::sim::Interpreter::new_with_wavedump(&ctx, &sys, waveform_file)
+    } else {
+        patronus::sim::Interpreter::new(&ctx, &sys)
+    };
+
     let mut scheduler = Scheduler::new(
         transactions_and_symbols,
         todos,

--- a/justfile
+++ b/justfile
@@ -1,7 +1,15 @@
+# Only run Turnt tests for the interpreter
+interp:
+  turnt --env interp $(find . -type f -name '*.tx')
+
+# Only run Turnt tests for the monitor
+monitor:
+  turnt --env monitor $(find . -type f -name '*.prot')
+
 # Runs all snapshot tests using Turnt
 turnt:
-  turnt --env interp $(find . -type f -name '*.tx')
-  turnt --env monitor $(find . -type f -name '*.prot')
+  @just interp  
+  @just monitor
 
 # Runs all unit tests (via Cargo) & snapshot tests (via Turnt)
 test:

--- a/protocols/src/errors.rs
+++ b/protocols/src/errors.rs
@@ -493,13 +493,13 @@ impl DiagnosticEmitter {
                 stmt_id,
             } => {
                 handler.emit_diagnostic_stmt(
-                    transaction, 
-                    stmt_id, 
+                    transaction,
+                    stmt_id,
                     &format!(
                         "Thread {} (transaction '{}') called `fork()` without previously calling `step()` first",
-                        thread_idx, 
+                        thread_idx,
                         transaction_name)
-                    , 
+                    ,
                     Level::Error
                 );
             }

--- a/protocols/src/errors.rs
+++ b/protocols/src/errors.rs
@@ -192,7 +192,7 @@ impl fmt::Display for ThreadError {
             } => {
                 write!(
                     f,
-                    "Thread {} (transaction '{}') called `fork()` without previously calling `step()` first",
+                    "Thread {} (transaction '{}') called `fork()` before calling `step()`",
                     thread_idx, transaction_name
                 )
             }
@@ -505,7 +505,7 @@ impl DiagnosticEmitter {
                     transaction,
                     stmt_id,
                     &format!(
-                        "Thread {} (transaction '{}') called `fork()` without previously calling `step()` first",
+                        "Thread {} (transaction '{}') called `fork()` before calling `step()`",
                         thread_idx, transaction_name
                     ),
                     Level::Error,

--- a/protocols/tests/adders/adder_d1/double_fork_error.out
+++ b/protocols/tests/adders/adder_d1/double_fork_error.out
@@ -1,0 +1,6 @@
+error: Thread 0 (transaction 'add_double_fork') attempted to fork more than once
+   ┌─ adders/adder_d1/double_fork_error.prot:15:3
+   │
+15 │   fork();
+   │   ^^^^^^^ Thread 0 (transaction 'add_double_fork') attempted to fork more than once
+

--- a/protocols/tests/adders/adder_d1/double_fork_error.out
+++ b/protocols/tests/adders/adder_d1/double_fork_error.out
@@ -1,6 +1,18 @@
 error: Thread 0 (transaction 'add_double_fork') attempted to fork more than once
-   ┌─ adders/adder_d1/double_fork_error.prot:15:3
+   ┌─ adders/adder_d1/double_fork_error.prot:12:3
    │
+12 │   fork();
+   │   ^^^^^^^ first fork() called here
+   ·
 15 │   fork();
-   │   ^^^^^^^ Thread 0 (transaction 'add_double_fork') attempted to fork more than once
+   │   ^^^^^^^ second fork() called here
+
+error: Thread 1 (transaction 'add_double_fork') attempted to fork more than once
+   ┌─ adders/adder_d1/double_fork_error.prot:12:3
+   │
+12 │   fork();
+   │   ^^^^^^^ first fork() called here
+   ·
+15 │   fork();
+   │   ^^^^^^^ second fork() called here
 

--- a/protocols/tests/adders/adder_d1/double_fork_error.prot
+++ b/protocols/tests/adders/adder_d1/double_fork_error.prot
@@ -1,0 +1,18 @@
+struct Adder {
+  in a: u32,
+  in b: u32,
+  out s: u32,
+}
+
+// This should fail since there are two forks
+fn add_double_fork<DUT: Adder>(in a: u32, in b: u32, out s: u32) {
+  DUT.a := a;
+  DUT.b := b;
+  step();
+  fork();
+  DUT.a := X;
+  DUT.b := X;
+  fork();
+  assert_eq(s, DUT.s);
+}
+

--- a/protocols/tests/adders/adder_d1/double_fork_error.tx
+++ b/protocols/tests/adders/adder_d1/double_fork_error.tx
@@ -1,0 +1,4 @@
+// ARGS: --verilog adders/adder_d1/add_d1.v --protocol adders/adder_d1/double_fork_error.prot
+// RETURN: 101
+add_double_fork(1, 2, 3);
+add_double_fork(4, 5, 9);

--- a/protocols/tests/adders/adder_d1/fork_before_step_error.out
+++ b/protocols/tests/adders/adder_d1/fork_before_step_error.out
@@ -1,6 +1,6 @@
-error: Thread 0 (transaction 'add_fork_before_step') called `fork()` without previously calling `step()` first
+error: Thread 0 (transaction 'add_fork_before_step') called `fork()` before calling `step()`
    ┌─ adders/adder_d1/fork_before_step_error.prot:11:3
    │
 11 │   fork();
-   │   ^^^^^^^ Thread 0 (transaction 'add_fork_before_step') called `fork()` without previously calling `step()` first
+   │   ^^^^^^^ Thread 0 (transaction 'add_fork_before_step') called `fork()` before calling `step()`
 

--- a/protocols/tests/adders/adder_d1/fork_before_step_error.out
+++ b/protocols/tests/adders/adder_d1/fork_before_step_error.out
@@ -1,0 +1,6 @@
+error: Thread 0 (transaction 'add_fork_before_step') called `fork()` without previously calling `step()` first
+   ┌─ adders/adder_d1/fork_before_step_error.prot:11:3
+   │
+11 │   fork();
+   │   ^^^^^^^ Thread 0 (transaction 'add_fork_before_step') called `fork()` without previously calling `step()` first
+

--- a/protocols/tests/adders/adder_d1/fork_before_step_error.prot
+++ b/protocols/tests/adders/adder_d1/fork_before_step_error.prot
@@ -1,0 +1,17 @@
+struct Adder {
+  in a: u32,
+  in b: u32,
+  out s: u32,
+}
+
+// This should fail since it calls `fork()` before calling `step`
+fn add_fork_before_step<DUT: Adder>(in a: u32, in b: u32, out s: u32) {
+  DUT.a := a;
+  DUT.b := b;
+  fork();
+  step();
+  DUT.a := X;
+  DUT.b := X;
+  assert_eq(s, DUT.s);
+}
+

--- a/protocols/tests/adders/adder_d1/fork_before_step_error.tx
+++ b/protocols/tests/adders/adder_d1/fork_before_step_error.tx
@@ -1,0 +1,4 @@
+// ARGS: --verilog adders/adder_d1/add_d1.v --protocol adders/adder_d1/fork_before_step_error.prot
+// RETURN: 101
+add_fork_before_step(1, 2, 3);
+add_fork_before_step(4, 5, 9);

--- a/protocols/tests/identities/identity_d2/two_fork_err.out
+++ b/protocols/tests/identities/identity_d2/two_fork_err.out
@@ -1,6 +1,9 @@
 error: Thread 0 (transaction 'two_fork_err') attempted to fork more than once
-   ┌─ identities/identity_d2/identity_d2.prot:24:3
+   ┌─ identities/identity_d2/identity_d2.prot:21:3
    │
+21 │   fork();
+   │   ^^^^^^^ first fork() called here
+   ·
 24 │   fork();
-   │   ^^^^^^^ Thread 0 (transaction 'two_fork_err') attempted to fork more than once
+   │   ^^^^^^^ second fork() called here
 

--- a/well-formedness.md
+++ b/well-formedness.md
@@ -9,6 +9,7 @@ Well-formed Protocols programs prevent the following bad things from happening.
 | Multiple threads try to assign to the same input                  | `ThreadError::ConflictingAssignment` |
 | We assign to a read-only symbol                                   | `ThreadError::ReadOnlyAssignment`    |
 | A thread attempts to `fork` more than once                        | `ThreadError::DoubleFork`            |
+| A thread calls `fork` before calling `step`                       | `ThreadError::ForkBeforeStep`        |
 | Performing an operation on a `DontCare`                           | `EvaluationError::DontCareOperation` |
 | A `DontCare` value is used as the guard for a loop / if-statement | `EvaluationError::DontCare`          |
 | We assert equality with a `DontCare` value                        | `AssertionError::DontCareAssertion`  |
@@ -16,7 +17,6 @@ Well-formed Protocols programs prevent the following bad things from happening.
 | Invalid slice operations                                          | `EvaluationError::InvalidSlice`      |
 | Non-termination (infinite `while` loops)                          | N/A                                  |
 
-**TODO:**
+**TODOs (implement these as dynamic checks):**
 - No `fork`s in program (per 9/30 meeting, a function must have exactly one `fork` somewhere in its body)
-- `fork` before `step`
 - Missing `step` at the end of a function

--- a/well-formedness.md
+++ b/well-formedness.md
@@ -14,5 +14,9 @@ Well-formed Protocols programs prevent the following bad things from happening.
 | We assert equality with a `DontCare` value                        | `AssertionError::DontCareAssertion`  |
 | Width mismatches in bitvec operations                             | `EvaluationError::ArithmeticError`   |
 | Invalid slice operations                                          | `EvaluationError::InvalidSlice`      |
-| Non-termination (infinite `while` loops)                          | (no type specified)                  |
+| Non-termination (infinite `while` loops)                          | N/A                                  |
 
+**TODO:**
+- No `fork`s in program (per 9/30 meeting, a function must have exactly one `fork` somewhere in its body)
+- `fork` before `step`
+- Missing `step` at the end of a function

--- a/well-formedness.md
+++ b/well-formedness.md
@@ -1,0 +1,18 @@
+# Well-Formedness
+
+Well-formed Protocols programs prevent the following bad things from happening.
+
+## Bad things that can happen at runtime
+
+| **Description**                                                   | **Error enum** (if one exists)       |
+|-------------------------------------------------------------------|--------------------------------------|
+| Multiple threads try to assign to the same input                  | `ThreadError::ConflictingAssignment` |
+| We assign to a read-only symbol                                   | `ThreadError::ReadOnlyAssignment`    |
+| A thread attempts to `fork` more than once                        | `ThreadError::DoubleFork`            |
+| Performing an operation on a `DontCare`                           | `EvaluationError::DontCareOperation` |
+| A `DontCare` value is used as the guard for a loop / if-statement | `EvaluationError::DontCare`          |
+| We assert equality with a `DontCare` value                        | `AssertionError::DontCareAssertion`  |
+| Width mismatches in bitvec operations                             | `EvaluationError::ArithmeticError`   |
+| Invalid slice operations                                          | `EvaluationError::InvalidSlice`      |
+| Non-termination (infinite `while` loops)                          | (no type specified)                  |
+


### PR DESCRIPTION
This PR makes the following changes:
- Adds docs for well-formedness checks (`well-formedness.md`)

- If we try to call `fork` without having previously called `step`, the interpreter throws an error:
```rust
error: Thread 0 (transaction 'add_fork_before_step') called `fork()` without previously calling `step()` first
   ┌─ adders/adder_d1/fork_before_step_error.prot:11:3
   │
11 │   fork();
   │   ^^^^^^^ Thread 0 (transaction 'add_fork_before_step') called `fork()` without previously calling `step()` first
```

- The error messages for `DoubleFork` errors now refer to the locations of the two forks to aid the user, e.g.
```rust
error: Thread 0 (transaction 'add_double_fork') attempted to fork more than once
   ┌─ adders/adder_d1/double_fork_error.prot:12:3
   │
12 │   fork();
   │   ^^^^^^^ first fork() called here
   ·
15 │   fork();
   │   ^^^^^^^ second fork() called here

```
- ^^ This required adding methods to `Diagnostic` to support referring to multiple statements within the same error message

- Made the output waveform file an _optional_ parameter in the interpreter CLI (this is so that we don't create a new `trace.fst` file for every Turnt test that is run)


**TODOs for a future PR**
- No `fork`s in program (per 9/30 meeting, a function must have exactly one `fork` somewhere in its body)
- Missing `step` at the end of a function
(I'm doing them in a separate PR since they involve modifying some existing Turnt tests in order for them to pass.)