### PR TITLE
Fix bugs in static well-formedness checks

### DIFF
--- a/protocols/src/errors.rs
+++ b/protocols/src/errors.rs
@@ -252,8 +252,11 @@ impl fmt::Display for ThreadError {
             } => {
                 write!(
                     f,
-                    "Thread {} attempted conflicting assignment to '{}': current={:?}, new={:?}",
-                    thread_idx, symbol_name, current_value, new_value
+                    "Thread {} attempted conflicting assignment to '{}': current={}, new={}",
+                    thread_idx,
+                    symbol_name,
+                    serialize_bitvec(current_value, false),
+                    serialize_bitvec(new_value, false)
                 )
             }
             ThreadError::ExecutionLimitExceeded { max_steps } => {

--- a/protocols/src/ir.rs
+++ b/protocols/src/ir.rs
@@ -179,7 +179,7 @@ impl Transaction {
 
     /// Determines if `symbol_id` is a function parameter with the desired `direction`
     /// (e.g. check if an identifier corresponds to an input parameter of the function)
-    pub fn is_param_with_correct_direction(&self, symbol_id: SymbolId, direction: Dir) -> bool {
+    pub fn is_param_with_direction(&self, symbol_id: SymbolId, direction: Dir) -> bool {
         self.get_parameters_by_direction(direction)
             .contains(&symbol_id)
     }

--- a/protocols/tests/inverters/inverter_d0.out
+++ b/protocols/tests/inverters/inverter_d0.out
@@ -1,6 +1,6 @@
-error: `DUT.s` is a output field of the struct `DUT`, but only input fields are allowed to appear in assignments)
-  ┌─ inverters/inverter_d0.prot:7:12
+error: Thread 0 attempted conflicting assignment to 'a': current=ValueOwned(11111111111111111111111111111111), new=ValueOwned(00000000000000000000000000000000)
+  ┌─ inverters/inverter_d0.prot:7:3
   │
 7 │   DUT.a := DUT.s;
-  │            ^^^^^ `DUT.s` is a output field of the struct `DUT`, but only input fields are allowed to appear in assignments)
+  │   ^^^^^^^^^^^^^^^ Thread 0 attempted conflicting assignment to 'a': current=ValueOwned(11111111111111111111111111111111), new=ValueOwned(00000000000000000000000000000000)
 

--- a/protocols/tests/inverters/inverter_d0.tx
+++ b/protocols/tests/inverters/inverter_d0.tx
@@ -1,3 +1,3 @@
 // ARGS: --verilog inverters/inverter_d0.v --protocol inverters/inverter_d0.prot
-// RETURN: 1
+// RETURN: 101
 invert(0, 1);

--- a/well-formedness.md
+++ b/well-formedness.md
@@ -19,7 +19,7 @@ RHS ::= rhs_expr
    | rhs_expr[i:j]          (bit-slice)
    | rhs_expr ++ rhs_expr   (where `++` is concatenation)
 
-rhs_expr ::= DUT input port | input parameter to a function | constant
+rhs_expr ::= input parameter to a function | constant
 ```
 - We also permit `LHS := X`, where `LHS` still a DUT input port & `X` is a distinguished `DontCare` symbol 
 that indicates the value of `LHS` is irrelevant at the current cycle.


### PR DESCRIPTION
This PR fixes a few bugs that Nikil noticed in the new static well-formedness checks (#117). 

**Assignments**: 
- Forbid DUT input ports from appearing on the RHS of assignments (fixed typo in `well-formedness.md`
- Allow DUT *output* ports to appear on the RHS of assignments per Nikil's Slack message below:

<img width="601" height="268" alt="Screenshot 2025-11-11 at 3 13 45 PM" src="https://github.com/user-attachments/assets/8f52ff89-51f2-49c6-8e9d-f75d0db8295d" />

Note: as a result of these checks, the expected output for the `inverter_d0` Turnt test is now a `Conflicting Thread Assignment` error that is detected *dynamically* (which is what we want), as opposed to an error message that says the assignment to the inverter is ill-formed.

**Assertions**:
- Fixed typo in error message (output parameters of functions are *allowed* to appear in `assert_eq`)
 