### PR TITLE
[Interp] Produce non-empty waveforms for combinational DUTs

### DIFF
--- a/protocols/src/scheduler.rs
+++ b/protocols/src/scheduler.rs
@@ -387,7 +387,7 @@ impl<'a> Scheduler<'a> {
             // Advance the simulator whenever a `step()` statement was
             // encountered this cycle.
             // This must happen even when all threads have completed and
-            // the `next_threads`` queue is empty, so that the waveform
+            // the `next_threads` queue is empty, so that the waveform
             // records a timestep for every `step()` statement in the protocol.
             // (Example: combinational adders which only contain one `step()`.
             // Without the following if-statement, the waveform would contain
@@ -395,6 +395,8 @@ impl<'a> Scheduler<'a> {
             if self.step_happened_this_cycle {
                 info!("Stepping...");
                 self.evaluator.sim_step();
+                // Reset flag to ensure that simulator is stepped exactly
+                // once during each cycle
                 self.step_happened_this_cycle = false;
             }
 


### PR DESCRIPTION
Note: merge #195 before reviewing this PR (I merged #195 into this PR since I found the Cargo aliases defined there helpful for running the interpreter executable, so he changed `.toml` files come from #195). The only changed file that is relevant to this PR is `interpreter.rs`. 

When debugging why the monitor was failing the `adder_d0` (combinational adder) round-trip test (#187), I noticed that the waveform produced by the interpreter was empty (Surfer had trouble opening the `.fst` file that was produced by the interpreter). I think the issue was that previously, the simulator's `sim_step()` method was only called when the `next_threads` queue is non-empty:

```rust
// scheduler.rs           
           ...
           // setup the threads for the next cycle
            if !self.next_threads.is_empty() {
                // advance simulation for next step
                info!("Stepping...");
                self.evaluator.sim_step();
                 ...
             }
```

However, for combinational DUTs like `adder_d0`, the `next_threads` queue is empty since all protocols defined with the same `.prot` file finish within the same cycle. As a result, the simulator never gets stepped, resulting in an empty waveform. 

The fix is to add an extra flag to the `Scheduler` struct that tracks whether a `step()` statement was encountered, and to call `sim_step()` on the simulator whenever a `step()` is encountered (regardless of whether the `next_threads` queue is empty or not). 

This allows the interpreter to produce a non-empty waveform for `adder_d0`!

<img width="1369" height="98" alt="Screenshot 2026-02-22 at 8 40 14 PM" src="https://github.com/user-attachments/assets/cf70d98a-8a8c-428e-90ab-b02a1c6eba4e" />

All other interpreter tests still pass after this change.

