### PR TITLE
(WIP) Add Tree-Sitter grammar

### DIFF
--- a/tools/zed/extension.toml
+++ b/tools/zed/extension.toml
@@ -1,0 +1,19 @@
+id = "protocols"
+name = "Protocols"
+description = "Syntax highlighting for Protocols (.prot) and Transactions (.tx) files"
+version = "0.0.1"
+schema_version = 1
+authors = ["Protocols Contributors"]
+repository = "https://github.com/cucapra/protocols"
+
+[grammars.protocols]
+repository = "https://github.com/cucapra/protocols"
+# TODO: Replace with the actual commit hash once this directory is committed
+commit = "0000000000000000000000000000000000000000"
+path = "tools/zed/grammars/protocols"
+
+[grammars.transactions]
+repository = "https://github.com/cucapra/protocols"
+# TODO: Replace with the actual commit hash once this directory is committed
+commit = "0000000000000000000000000000000000000000"
+path = "tools/zed/grammars/transactions"

--- a/tools/zed/grammars/.gitignore
+++ b/tools/zed/grammars/.gitignore
@@ -1,0 +1,6 @@
+# Tree-sitter generated/compiled output — regenerate with `tree-sitter generate`
+*/src/
+*/node_modules/
+*/bindings/
+*/binding.gyp
+*.wasm

--- a/tools/zed/grammars/protocols/.gitignore
+++ b/tools/zed/grammars/protocols/.gitignore
@@ -1,0 +1,37 @@
+# Rust artifacts
+target/
+
+# Node artifacts
+build/
+prebuilds/
+node_modules/
+*.tgz
+
+# Swift artifacts
+.build/
+Package.resolved
+
+# Go artifacts
+_obj/
+
+# Python artifacts
+.venv/
+dist/
+*.egg-info
+*.whl
+
+# C artifacts
+*.a
+*.so
+*.so.*
+*.dylib
+*.dll
+*.pc
+
+# Example dirs
+/examples/*/
+
+# Grammar volatiles
+*.wasm
+*.obj
+*.o

--- a/tools/zed/grammars/protocols/Cargo.toml
+++ b/tools/zed/grammars/protocols/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "tree-sitter-protocols"
+description = "Protocols grammar for tree-sitter"
+version = "0.0.1"
+license = "MIT"
+readme = "README.md"
+keywords = ["incremental", "parsing", "tree-sitter", "protocols"]
+categories = ["parsing", "text-editors"]
+repository = "https://github.com/tree-sitter/tree-sitter-protocols"
+edition = "2021"
+autoexamples = false
+
+build = "bindings/rust/build.rs"
+include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
+
+[lib]
+path = "bindings/rust/lib.rs"
+
+[dependencies]
+tree-sitter-language = "0.1"
+
+[build-dependencies]
+cc = "1.0.87"
+
+[dev-dependencies]
+tree-sitter = "0.23"

--- a/tools/zed/grammars/protocols/Makefile
+++ b/tools/zed/grammars/protocols/Makefile
@@ -1,0 +1,114 @@
+ifeq ($(OS),Windows_NT)
+$(error Windows is not supported)
+endif
+
+VERSION := 0.0.1
+
+LANGUAGE_NAME := tree-sitter-protocols
+
+# repository
+SRC_DIR := src
+
+PARSER_REPO_URL := $(shell git -C $(SRC_DIR) remote get-url origin 2>/dev/null)
+
+ifeq ($(PARSER_URL),)
+	PARSER_URL := $(subst .git,,$(PARSER_REPO_URL))
+ifeq ($(shell echo $(PARSER_URL) | grep '^[a-z][-+.0-9a-z]*://'),)
+	PARSER_URL := $(subst :,/,$(PARSER_URL))
+	PARSER_URL := $(subst git@,https://,$(PARSER_URL))
+endif
+endif
+
+TS ?= tree-sitter
+
+# install directory layout
+PREFIX ?= /usr/local
+INCLUDEDIR ?= $(PREFIX)/include
+LIBDIR ?= $(PREFIX)/lib
+PCLIBDIR ?= $(LIBDIR)/pkgconfig
+
+# source/object files
+PARSER := $(SRC_DIR)/parser.c
+EXTRAS := $(filter-out $(PARSER),$(wildcard $(SRC_DIR)/*.c))
+OBJS := $(patsubst %.c,%.o,$(PARSER) $(EXTRAS))
+
+# flags
+ARFLAGS ?= rcs
+override CFLAGS += -I$(SRC_DIR) -std=c11 -fPIC
+
+# ABI versioning
+SONAME_MAJOR := $(word 1,$(subst ., ,$(VERSION)))
+SONAME_MINOR := $(shell sed -n 's/#define LANGUAGE_VERSION //p' $(PARSER))
+
+# OS-specific bits
+ifeq ($(shell uname),Darwin)
+	SOEXT = dylib
+	SOEXTVER_MAJOR = $(SONAME_MAJOR).$(SOEXT)
+	SOEXTVER = $(SONAME_MAJOR).$(SONAME_MINOR).$(SOEXT)
+	LINKSHARED := $(LINKSHARED)-dynamiclib -Wl,
+	ifneq ($(ADDITIONAL_LIBS),)
+	LINKSHARED := $(LINKSHARED)$(ADDITIONAL_LIBS),
+	endif
+	LINKSHARED := $(LINKSHARED)-install_name,$(LIBDIR)/lib$(LANGUAGE_NAME).$(SOEXTVER),-rpath,@executable_path/../Frameworks
+else
+	SOEXT = so
+	SOEXTVER_MAJOR = $(SOEXT).$(SONAME_MAJOR)
+	SOEXTVER = $(SOEXT).$(SONAME_MAJOR).$(SONAME_MINOR)
+	LINKSHARED := $(LINKSHARED)-shared -Wl,
+	ifneq ($(ADDITIONAL_LIBS),)
+	LINKSHARED := $(LINKSHARED)$(ADDITIONAL_LIBS)
+	endif
+	LINKSHARED := $(LINKSHARED)-soname,lib$(LANGUAGE_NAME).$(SOEXTVER)
+endif
+ifneq ($(filter $(shell uname),FreeBSD NetBSD DragonFly),)
+	PCLIBDIR := $(PREFIX)/libdata/pkgconfig
+endif
+
+all: lib$(LANGUAGE_NAME).a lib$(LANGUAGE_NAME).$(SOEXT) $(LANGUAGE_NAME).pc
+
+lib$(LANGUAGE_NAME).a: $(OBJS)
+	$(AR) $(ARFLAGS) $@ $^
+
+lib$(LANGUAGE_NAME).$(SOEXT): $(OBJS)
+	$(CC) $(LDFLAGS) $(LINKSHARED) $^ $(LDLIBS) -o $@
+ifneq ($(STRIP),)
+	$(STRIP) $@
+endif
+
+$(LANGUAGE_NAME).pc: bindings/c/$(LANGUAGE_NAME).pc.in
+	sed  -e 's|@URL@|$(PARSER_URL)|' \
+		-e 's|@VERSION@|$(VERSION)|' \
+		-e 's|@LIBDIR@|$(LIBDIR)|' \
+		-e 's|@INCLUDEDIR@|$(INCLUDEDIR)|' \
+		-e 's|@REQUIRES@|$(REQUIRES)|' \
+		-e 's|@ADDITIONAL_LIBS@|$(ADDITIONAL_LIBS)|' \
+		-e 's|=$(PREFIX)|=$${prefix}|' \
+		-e 's|@PREFIX@|$(PREFIX)|' $< > $@
+
+$(PARSER): $(SRC_DIR)/grammar.json
+	$(TS) generate --no-bindings $^
+
+install: all
+	install -d '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter '$(DESTDIR)$(PCLIBDIR)' '$(DESTDIR)$(LIBDIR)'
+	install -m644 bindings/c/$(LANGUAGE_NAME).h '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter/$(LANGUAGE_NAME).h
+	install -m644 $(LANGUAGE_NAME).pc '$(DESTDIR)$(PCLIBDIR)'/$(LANGUAGE_NAME).pc
+	install -m644 lib$(LANGUAGE_NAME).a '$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).a
+	install -m755 lib$(LANGUAGE_NAME).$(SOEXT) '$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).$(SOEXTVER)
+	ln -sf lib$(LANGUAGE_NAME).$(SOEXTVER) '$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).$(SOEXTVER_MAJOR)
+	ln -sf lib$(LANGUAGE_NAME).$(SOEXTVER_MAJOR) '$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).$(SOEXT)
+
+uninstall:
+	$(RM) '$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).a \
+		'$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).$(SOEXTVER) \
+		'$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).$(SOEXTVER_MAJOR) \
+		'$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).$(SOEXT) \
+		'$(DESTDIR)$(INCLUDEDIR)'/tree_sitter/$(LANGUAGE_NAME).h \
+		'$(DESTDIR)$(PCLIBDIR)'/$(LANGUAGE_NAME).pc
+
+clean:
+	$(RM) $(OBJS) $(LANGUAGE_NAME).pc lib$(LANGUAGE_NAME).a lib$(LANGUAGE_NAME).$(SOEXT)
+
+test:
+	$(TS) test
+
+.PHONY: all install uninstall clean test

--- a/tools/zed/grammars/protocols/Package.swift
+++ b/tools/zed/grammars/protocols/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitterProtocols",
+    products: [
+        .library(name: "TreeSitterProtocols", targets: ["TreeSitterProtocols"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/ChimeHQ/SwiftTreeSitter", from: "0.8.0"),
+    ],
+    targets: [
+        .target(
+            name: "TreeSitterProtocols",
+            dependencies: [],
+            path: ".",
+            sources: [
+                "src/parser.c",
+                // NOTE: if your language has an external scanner, add it here.
+            ],
+            resources: [
+                .copy("queries")
+            ],
+            publicHeadersPath: "bindings/swift",
+            cSettings: [.headerSearchPath("src")]
+        ),
+        .testTarget(
+            name: "TreeSitterProtocolsTests",
+            dependencies: [
+                "SwiftTreeSitter",
+                "TreeSitterProtocols",
+            ],
+            path: "bindings/swift/TreeSitterProtocolsTests"
+        )
+    ],
+    cLanguageStandard: .c11
+)

--- a/tools/zed/grammars/protocols/go.mod
+++ b/tools/zed/grammars/protocols/go.mod
@@ -1,0 +1,5 @@
+module github.com/tree-sitter/tree-sitter-protocols
+
+go 1.23
+
+require github.com/tree-sitter/go-tree-sitter v0.23.1

--- a/tools/zed/grammars/protocols/grammar.js
+++ b/tools/zed/grammars/protocols/grammar.js
@@ -1,0 +1,220 @@
+// Tree-sitter grammar for the Protocols language (.prot files).
+// Derived from protocols/src/protocols.pest.
+
+module.exports = grammar({
+  name: "protocols",
+
+  // Comments and whitespace can appear anywhere between tokens.
+  extras: ($) => [/\s+/, $.comment],
+
+  // Declare `identifier` as the "word" token so that string literals
+  // that match the identifier pattern (e.g. "struct", "X") are treated
+  // as reserved keywords and take lexical precedence over identifiers.
+  word: ($) => $.identifier,
+
+  rules: {
+    source_file: ($) => repeat($._item),
+
+    _item: ($) => choice($.struct_definition, $.protocol_definition),
+
+    // Line comment: // ...
+    // The language only has line comments (no block comments).
+    comment: ($) => token(seq("//", /.*/)),
+
+    // Annotation: #[idle]
+    annotation: ($) => seq("#[", field("name", $.identifier), "]"),
+
+    // struct Name { arg, arg, ... }
+    struct_definition: ($) =>
+      seq(
+        "struct",
+        field("name", $.path_id),
+        "{",
+        optional($.arg_list),
+        "}"
+      ),
+
+    // annotation? prot Name<TypeParam>(args) { body }
+    protocol_definition: ($) =>
+      seq(
+        optional($.annotation),
+        "prot",
+        field("name", $.path_id),
+        $.type_param,
+        "(",
+        optional($.arg_list),
+        ")",
+        field("body", $.block)
+      ),
+
+    // <name : Type>
+    type_param: ($) =>
+      seq(
+        "<",
+        field("name", $.path_id),
+        ":",
+        field("type", $.path_id),
+        ">"
+      ),
+
+    // Comma-separated argument list (trailing comma allowed)
+    arg_list: ($) => seq($.arg, repeat(seq(",", $.arg)), optional(",")),
+
+    // dir name : type
+    arg: ($) =>
+      seq(
+        field("direction", $.direction),
+        field("name", $.path_id),
+        ":",
+        field("type", $.type)
+      ),
+
+    direction: ($) => choice("in", "out"),
+
+    // { stmt* }
+    block: ($) => seq("{", repeat($._statement), "}"),
+
+    _statement: ($) =>
+      choice(
+        $.assignment_statement,
+        $.step_statement,
+        $.fork_statement,
+        $.while_statement,
+        $.repeat_statement,
+        $.assert_statement,
+        $.if_statement
+      ),
+
+    // path_id := expr ;
+    assignment_statement: ($) =>
+      seq(field("target", $.path_id), ":=", field("value", $._expression), ";"),
+
+    // step ( dec_integer? ) ;
+    step_statement: ($) =>
+      seq("step", "(", optional($.dec_integer), ")", ";"),
+
+    // fork () ;
+    fork_statement: ($) => seq("fork", "(", ")", ";"),
+
+    // while expr { stmt* }
+    // No parentheses around condition — parens come from paren_expression if written.
+    while_statement: ($) =>
+      seq(
+        "while",
+        field("condition", $._expression),
+        field("body", $.block)
+      ),
+
+    // repeat expr iterations { stmt* }
+    repeat_statement: ($) =>
+      seq(
+        "repeat",
+        field("count", $._expression),
+        "iterations",
+        field("body", $.block)
+      ),
+
+    // assert_eq ( expr , expr ) ;
+    assert_statement: ($) =>
+      seq(
+        "assert_eq",
+        "(",
+        field("left", $._expression),
+        ",",
+        field("right", $._expression),
+        ")",
+        ";"
+      ),
+
+    // if expr { stmt* } (else { stmt* })?
+    if_statement: ($) =>
+      seq(
+        "if",
+        field("condition", $._expression),
+        field("consequence", $.block),
+        optional(seq("else", field("alternative", $.block)))
+      ),
+
+    // ── Expressions ──────────────────────────────────────────────────────────
+
+    _expression: ($) =>
+      choice(
+        $.binary_expression,
+        $.unary_expression,
+        $.slice_expression,
+        $.paren_expression,
+        $.integer_literal,
+        $.wildcard,
+        $.path_id
+      ),
+
+    // atom == atom  (prec 2)
+    // atom +  atom  (prec 1)
+    binary_expression: ($) =>
+      choice(
+        prec.left(
+          2,
+          seq(
+            field("left", $._expression),
+            "==",
+            field("right", $._expression)
+          )
+        ),
+        prec.left(
+          1,
+          seq(
+            field("left", $._expression),
+            "+",
+            field("right", $._expression)
+          )
+        )
+      ),
+
+    // ! expr
+    unary_expression: ($) =>
+      prec(3, seq(field("operator", $.not_op), field("operand", $._expression))),
+
+    not_op: ($) => "!",
+
+    // path_id [ high : low ]  or  path_id [ index ]
+    slice_expression: ($) =>
+      seq(
+        field("base", $.path_id),
+        "[",
+        field("high", $.dec_integer),
+        optional(seq(":", field("low", $.dec_integer))),
+        "]"
+      ),
+
+    // ( expr )
+    paren_expression: ($) => seq("(", $._expression, ")"),
+
+    // Don't-care wildcard: X
+    wildcard: ($) => token("X"),
+
+    // ── Terminals ─────────────────────────────────────────────────────────────
+
+    // Built-in type: u<digits>  e.g. u1, u8, u32, u128
+    type: ($) => /u[0-9]+/,
+
+    // Dotted path: a.b.c
+    path_id: ($) => seq($.identifier, repeat(seq(".", $.identifier))),
+
+    // Width-prefixed integer: width'base digits
+    //   e.g.  8'b1010_1010  16'hDEAD  32'd42  8'o77
+    integer_literal: ($) =>
+      token(
+        choice(
+          /[0-9][0-9_]*'[bB][01_]+/,
+          /[0-9][0-9_]*'[oO][0-7_]+/,
+          /[0-9][0-9_]*'[xX][0-9a-fA-F_]+/,
+          /[0-9][0-9_]*'[dD][0-9_]+/
+        )
+      ),
+
+    // Plain decimal integer (used in step() argument and slice indices)
+    dec_integer: ($) => /[0-9][0-9_]*/,
+
+    identifier: ($) => /[a-zA-Z_][a-zA-Z0-9_]*/,
+  },
+});

--- a/tools/zed/grammars/protocols/pyproject.toml
+++ b/tools/zed/grammars/protocols/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tree-sitter-protocols"
+description = "Protocols grammar for tree-sitter"
+version = "0.0.1"
+keywords = ["incremental", "parsing", "tree-sitter", "protocols"]
+classifiers = [
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Topic :: Software Development :: Compilers",
+  "Topic :: Text Processing :: Linguistic",
+  "Typing :: Typed"
+]
+requires-python = ">=3.9"
+license.text = "MIT"
+readme = "README.md"
+
+[project.urls]
+Homepage = "https://github.com/tree-sitter/tree-sitter-protocols"
+
+[project.optional-dependencies]
+core = ["tree-sitter~=0.22"]
+
+[tool.cibuildwheel]
+build = "cp39-*"
+build-frontend = "build"

--- a/tools/zed/grammars/protocols/setup.py
+++ b/tools/zed/grammars/protocols/setup.py
@@ -1,0 +1,62 @@
+from os.path import isdir, join
+from platform import system
+
+from setuptools import Extension, find_packages, setup
+from setuptools.command.build import build
+from wheel.bdist_wheel import bdist_wheel
+
+
+class Build(build):
+    def run(self):
+        if isdir("queries"):
+            dest = join(self.build_lib, "tree_sitter_protocols", "queries")
+            self.copy_tree("queries", dest)
+        super().run()
+
+
+class BdistWheel(bdist_wheel):
+    def get_tag(self):
+        python, abi, platform = super().get_tag()
+        if python.startswith("cp"):
+            python, abi = "cp39", "abi3"
+        return python, abi, platform
+
+
+setup(
+    packages=find_packages("bindings/python"),
+    package_dir={"": "bindings/python"},
+    package_data={
+        "tree_sitter_protocols": ["*.pyi", "py.typed"],
+        "tree_sitter_protocols.queries": ["*.scm"],
+    },
+    ext_package="tree_sitter_protocols",
+    ext_modules=[
+        Extension(
+            name="_binding",
+            sources=[
+                "bindings/python/tree_sitter_protocols/binding.c",
+                "src/parser.c",
+                # NOTE: if your language uses an external scanner, add it here.
+            ],
+            extra_compile_args=[
+                "-std=c11",
+                "-fvisibility=hidden",
+            ] if system() != "Windows" else [
+                "/std:c11",
+                "/utf-8",
+            ],
+            define_macros=[
+                ("Py_LIMITED_API", "0x03090000"),
+                ("PY_SSIZE_T_CLEAN", None),
+                ("TREE_SITTER_HIDE_SYMBOLS", None),
+            ],
+            include_dirs=["src"],
+            py_limited_api=True,
+        )
+    ],
+    cmdclass={
+        "build": Build,
+        "bdist_wheel": BdistWheel
+    },
+    zip_safe=False
+)

--- a/tools/zed/grammars/transactions/.gitignore
+++ b/tools/zed/grammars/transactions/.gitignore
@@ -1,0 +1,37 @@
+# Rust artifacts
+target/
+
+# Node artifacts
+build/
+prebuilds/
+node_modules/
+*.tgz
+
+# Swift artifacts
+.build/
+Package.resolved
+
+# Go artifacts
+_obj/
+
+# Python artifacts
+.venv/
+dist/
+*.egg-info
+*.whl
+
+# C artifacts
+*.a
+*.so
+*.so.*
+*.dylib
+*.dll
+*.pc
+
+# Example dirs
+/examples/*/
+
+# Grammar volatiles
+*.wasm
+*.obj
+*.o

--- a/tools/zed/grammars/transactions/Cargo.toml
+++ b/tools/zed/grammars/transactions/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "tree-sitter-transactions"
+description = "Transactions grammar for tree-sitter"
+version = "0.0.1"
+license = "MIT"
+readme = "README.md"
+keywords = ["incremental", "parsing", "tree-sitter", "transactions"]
+categories = ["parsing", "text-editors"]
+repository = "https://github.com/tree-sitter/tree-sitter-transactions"
+edition = "2021"
+autoexamples = false
+
+build = "bindings/rust/build.rs"
+include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
+
+[lib]
+path = "bindings/rust/lib.rs"
+
+[dependencies]
+tree-sitter-language = "0.1"
+
+[build-dependencies]
+cc = "1.0.87"
+
+[dev-dependencies]
+tree-sitter = "0.23"

--- a/tools/zed/grammars/transactions/Makefile
+++ b/tools/zed/grammars/transactions/Makefile
@@ -1,0 +1,114 @@
+ifeq ($(OS),Windows_NT)
+$(error Windows is not supported)
+endif
+
+VERSION := 0.0.1
+
+LANGUAGE_NAME := tree-sitter-transactions
+
+# repository
+SRC_DIR := src
+
+PARSER_REPO_URL := $(shell git -C $(SRC_DIR) remote get-url origin 2>/dev/null)
+
+ifeq ($(PARSER_URL),)
+	PARSER_URL := $(subst .git,,$(PARSER_REPO_URL))
+ifeq ($(shell echo $(PARSER_URL) | grep '^[a-z][-+.0-9a-z]*://'),)
+	PARSER_URL := $(subst :,/,$(PARSER_URL))
+	PARSER_URL := $(subst git@,https://,$(PARSER_URL))
+endif
+endif
+
+TS ?= tree-sitter
+
+# install directory layout
+PREFIX ?= /usr/local
+INCLUDEDIR ?= $(PREFIX)/include
+LIBDIR ?= $(PREFIX)/lib
+PCLIBDIR ?= $(LIBDIR)/pkgconfig
+
+# source/object files
+PARSER := $(SRC_DIR)/parser.c
+EXTRAS := $(filter-out $(PARSER),$(wildcard $(SRC_DIR)/*.c))
+OBJS := $(patsubst %.c,%.o,$(PARSER) $(EXTRAS))
+
+# flags
+ARFLAGS ?= rcs
+override CFLAGS += -I$(SRC_DIR) -std=c11 -fPIC
+
+# ABI versioning
+SONAME_MAJOR := $(word 1,$(subst ., ,$(VERSION)))
+SONAME_MINOR := $(shell sed -n 's/#define LANGUAGE_VERSION //p' $(PARSER))
+
+# OS-specific bits
+ifeq ($(shell uname),Darwin)
+	SOEXT = dylib
+	SOEXTVER_MAJOR = $(SONAME_MAJOR).$(SOEXT)
+	SOEXTVER = $(SONAME_MAJOR).$(SONAME_MINOR).$(SOEXT)
+	LINKSHARED := $(LINKSHARED)-dynamiclib -Wl,
+	ifneq ($(ADDITIONAL_LIBS),)
+	LINKSHARED := $(LINKSHARED)$(ADDITIONAL_LIBS),
+	endif
+	LINKSHARED := $(LINKSHARED)-install_name,$(LIBDIR)/lib$(LANGUAGE_NAME).$(SOEXTVER),-rpath,@executable_path/../Frameworks
+else
+	SOEXT = so
+	SOEXTVER_MAJOR = $(SOEXT).$(SONAME_MAJOR)
+	SOEXTVER = $(SOEXT).$(SONAME_MAJOR).$(SONAME_MINOR)
+	LINKSHARED := $(LINKSHARED)-shared -Wl,
+	ifneq ($(ADDITIONAL_LIBS),)
+	LINKSHARED := $(LINKSHARED)$(ADDITIONAL_LIBS)
+	endif
+	LINKSHARED := $(LINKSHARED)-soname,lib$(LANGUAGE_NAME).$(SOEXTVER)
+endif
+ifneq ($(filter $(shell uname),FreeBSD NetBSD DragonFly),)
+	PCLIBDIR := $(PREFIX)/libdata/pkgconfig
+endif
+
+all: lib$(LANGUAGE_NAME).a lib$(LANGUAGE_NAME).$(SOEXT) $(LANGUAGE_NAME).pc
+
+lib$(LANGUAGE_NAME).a: $(OBJS)
+	$(AR) $(ARFLAGS) $@ $^
+
+lib$(LANGUAGE_NAME).$(SOEXT): $(OBJS)
+	$(CC) $(LDFLAGS) $(LINKSHARED) $^ $(LDLIBS) -o $@
+ifneq ($(STRIP),)
+	$(STRIP) $@
+endif
+
+$(LANGUAGE_NAME).pc: bindings/c/$(LANGUAGE_NAME).pc.in
+	sed  -e 's|@URL@|$(PARSER_URL)|' \
+		-e 's|@VERSION@|$(VERSION)|' \
+		-e 's|@LIBDIR@|$(LIBDIR)|' \
+		-e 's|@INCLUDEDIR@|$(INCLUDEDIR)|' \
+		-e 's|@REQUIRES@|$(REQUIRES)|' \
+		-e 's|@ADDITIONAL_LIBS@|$(ADDITIONAL_LIBS)|' \
+		-e 's|=$(PREFIX)|=$${prefix}|' \
+		-e 's|@PREFIX@|$(PREFIX)|' $< > $@
+
+$(PARSER): $(SRC_DIR)/grammar.json
+	$(TS) generate --no-bindings $^
+
+install: all
+	install -d '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter '$(DESTDIR)$(PCLIBDIR)' '$(DESTDIR)$(LIBDIR)'
+	install -m644 bindings/c/$(LANGUAGE_NAME).h '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter/$(LANGUAGE_NAME).h
+	install -m644 $(LANGUAGE_NAME).pc '$(DESTDIR)$(PCLIBDIR)'/$(LANGUAGE_NAME).pc
+	install -m644 lib$(LANGUAGE_NAME).a '$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).a
+	install -m755 lib$(LANGUAGE_NAME).$(SOEXT) '$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).$(SOEXTVER)
+	ln -sf lib$(LANGUAGE_NAME).$(SOEXTVER) '$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).$(SOEXTVER_MAJOR)
+	ln -sf lib$(LANGUAGE_NAME).$(SOEXTVER_MAJOR) '$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).$(SOEXT)
+
+uninstall:
+	$(RM) '$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).a \
+		'$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).$(SOEXTVER) \
+		'$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).$(SOEXTVER_MAJOR) \
+		'$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).$(SOEXT) \
+		'$(DESTDIR)$(INCLUDEDIR)'/tree_sitter/$(LANGUAGE_NAME).h \
+		'$(DESTDIR)$(PCLIBDIR)'/$(LANGUAGE_NAME).pc
+
+clean:
+	$(RM) $(OBJS) $(LANGUAGE_NAME).pc lib$(LANGUAGE_NAME).a lib$(LANGUAGE_NAME).$(SOEXT)
+
+test:
+	$(TS) test
+
+.PHONY: all install uninstall clean test

--- a/tools/zed/grammars/transactions/Package.swift
+++ b/tools/zed/grammars/transactions/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitterTransactions",
+    products: [
+        .library(name: "TreeSitterTransactions", targets: ["TreeSitterTransactions"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/ChimeHQ/SwiftTreeSitter", from: "0.8.0"),
+    ],
+    targets: [
+        .target(
+            name: "TreeSitterTransactions",
+            dependencies: [],
+            path: ".",
+            sources: [
+                "src/parser.c",
+                // NOTE: if your language has an external scanner, add it here.
+            ],
+            resources: [
+                .copy("queries")
+            ],
+            publicHeadersPath: "bindings/swift",
+            cSettings: [.headerSearchPath("src")]
+        ),
+        .testTarget(
+            name: "TreeSitterTransactionsTests",
+            dependencies: [
+                "SwiftTreeSitter",
+                "TreeSitterTransactions",
+            ],
+            path: "bindings/swift/TreeSitterTransactionsTests"
+        )
+    ],
+    cLanguageStandard: .c11
+)

--- a/tools/zed/grammars/transactions/go.mod
+++ b/tools/zed/grammars/transactions/go.mod
@@ -1,0 +1,5 @@
+module github.com/tree-sitter/tree-sitter-transactions
+
+go 1.23
+
+require github.com/tree-sitter/go-tree-sitter v0.23.1

--- a/tools/zed/grammars/transactions/grammar.js
+++ b/tools/zed/grammars/transactions/grammar.js
@@ -1,0 +1,61 @@
+// Tree-sitter grammar for Protocols Transactions files (.tx files).
+// Derived from protocols/src/transactions.pest.
+
+module.exports = grammar({
+  name: "transactions",
+
+  extras: ($) => [/\s+/],
+
+  word: ($) => $.identifier,
+
+  rules: {
+    source_file: ($) => repeat($._item),
+
+    _item: ($) => choice($.directive_comment, $.comment, $.trace_block),
+
+    // Directive comments: // ARGS: ... or // RETURN: ...
+    // Given higher lexical precedence than plain comments so they are
+    // preferred when both patterns could match.
+    directive_comment: ($) =>
+      token(prec(1, /\/\/\s*(ARGS|RETURN):.*/)),
+
+    // Plain line comment: // ...
+    comment: ($) => token(/\/.*/),
+
+    // trace { transaction* }
+    trace_block: ($) =>
+      seq("trace", "{", repeat($._trace_item), "}"),
+
+    _trace_item: ($) => choice($.comment, $.transaction),
+
+    // ident ( arglist? ) ;
+    transaction: ($) =>
+      seq(
+        field("function", $.identifier),
+        "(",
+        optional($.arg_list),
+        ")",
+        ";"
+      ),
+
+    // Comma-separated integer arguments (trailing comma allowed)
+    arg_list: ($) =>
+      seq(
+        $.integer_literal,
+        repeat(seq(",", $.integer_literal)),
+        optional(",")
+      ),
+
+    // Integer literals: 0b..., 0x..., decimal
+    integer_literal: ($) =>
+      token(
+        choice(
+          /0[bB][01_]+/,
+          /0[xX][0-9a-fA-F_]+/,
+          /[0-9][0-9_]*/
+        )
+      ),
+
+    identifier: ($) => /[a-zA-Z_][a-zA-Z0-9_]*/,
+  },
+});

--- a/tools/zed/grammars/transactions/pyproject.toml
+++ b/tools/zed/grammars/transactions/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tree-sitter-transactions"
+description = "Transactions grammar for tree-sitter"
+version = "0.0.1"
+keywords = ["incremental", "parsing", "tree-sitter", "transactions"]
+classifiers = [
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Topic :: Software Development :: Compilers",
+  "Topic :: Text Processing :: Linguistic",
+  "Typing :: Typed"
+]
+requires-python = ">=3.9"
+license.text = "MIT"
+readme = "README.md"
+
+[project.urls]
+Homepage = "https://github.com/tree-sitter/tree-sitter-transactions"
+
+[project.optional-dependencies]
+core = ["tree-sitter~=0.22"]
+
+[tool.cibuildwheel]
+build = "cp39-*"
+build-frontend = "build"

--- a/tools/zed/grammars/transactions/setup.py
+++ b/tools/zed/grammars/transactions/setup.py
@@ -1,0 +1,62 @@
+from os.path import isdir, join
+from platform import system
+
+from setuptools import Extension, find_packages, setup
+from setuptools.command.build import build
+from wheel.bdist_wheel import bdist_wheel
+
+
+class Build(build):
+    def run(self):
+        if isdir("queries"):
+            dest = join(self.build_lib, "tree_sitter_transactions", "queries")
+            self.copy_tree("queries", dest)
+        super().run()
+
+
+class BdistWheel(bdist_wheel):
+    def get_tag(self):
+        python, abi, platform = super().get_tag()
+        if python.startswith("cp"):
+            python, abi = "cp39", "abi3"
+        return python, abi, platform
+
+
+setup(
+    packages=find_packages("bindings/python"),
+    package_dir={"": "bindings/python"},
+    package_data={
+        "tree_sitter_transactions": ["*.pyi", "py.typed"],
+        "tree_sitter_transactions.queries": ["*.scm"],
+    },
+    ext_package="tree_sitter_transactions",
+    ext_modules=[
+        Extension(
+            name="_binding",
+            sources=[
+                "bindings/python/tree_sitter_transactions/binding.c",
+                "src/parser.c",
+                # NOTE: if your language uses an external scanner, add it here.
+            ],
+            extra_compile_args=[
+                "-std=c11",
+                "-fvisibility=hidden",
+            ] if system() != "Windows" else [
+                "/std:c11",
+                "/utf-8",
+            ],
+            define_macros=[
+                ("Py_LIMITED_API", "0x03090000"),
+                ("PY_SSIZE_T_CLEAN", None),
+                ("TREE_SITTER_HIDE_SYMBOLS", None),
+            ],
+            include_dirs=["src"],
+            py_limited_api=True,
+        )
+    ],
+    cmdclass={
+        "build": Build,
+        "bdist_wheel": BdistWheel
+    },
+    zip_safe=False
+)

--- a/tools/zed/languages/protocols/config.toml
+++ b/tools/zed/languages/protocols/config.toml
@@ -1,0 +1,4 @@
+name = "Protocols"
+grammar = "protocols"
+path_suffixes = ["prot"]
+line_comments = ["// "]

--- a/tools/zed/languages/protocols/highlights.scm
+++ b/tools/zed/languages/protocols/highlights.scm
@@ -1,0 +1,80 @@
+; ── Comments ──────────────────────────────────────────────────────────────────
+
+(comment) @comment
+
+; ── Annotations ───────────────────────────────────────────────────────────────
+
+; #[idle]  →  highlight the whole annotation as an attribute
+(annotation) @attribute
+
+; ── Keywords ──────────────────────────────────────────────────────────────────
+
+; Declaration keywords
+"struct" @keyword.type
+"prot"   @keyword.type
+
+; Direction modifiers (in / out)
+"in"  @keyword.modifier
+"out" @keyword.modifier
+
+; Control-flow keywords
+"if"         @keyword.control
+"else"       @keyword.control
+"while"      @keyword.control
+"repeat"     @keyword.control
+"iterations" @keyword.control
+
+; Built-in statement keywords (step, fork, assert_eq)
+"step"      @function.builtin
+"fork"      @function.builtin
+"assert_eq" @function.builtin
+
+; ── Types ─────────────────────────────────────────────────────────────────────
+
+; u1, u8, u16, u32, u64, u128, …
+(type) @type.builtin
+
+; ── Named definitions ─────────────────────────────────────────────────────────
+
+; struct Adder { … }  →  "Adder" is a type name
+(struct_definition name: (path_id (identifier) @type))
+
+; prot send_data<…>(…) { … }  →  "send_data" is a function name
+(protocol_definition name: (path_id . (identifier) @function))
+
+; ── Type parameters ───────────────────────────────────────────────────────────
+
+; <DUT : Adder>  →  "DUT" is a parameter, "Adder" is a type
+(type_param name: (path_id (identifier) @variable.parameter))
+(type_param type: (path_id (identifier) @type))
+
+; ── Argument / parameter declarations ────────────────────────────────────────
+
+; in a : u32  →  "a" is a parameter name
+(arg name: (path_id . (identifier) @variable.parameter))
+
+; ── Expressions ───────────────────────────────────────────────────────────────
+
+; Dotted paths:  DUT.a  →  "DUT" = variable,  "a" = member
+; Must come before the general path_id rule so members take priority.
+(path_id "." (identifier) @variable.member)
+(path_id . (identifier) @variable)
+
+; Don't-care wildcard: X
+(wildcard) @constant.builtin
+
+; Integers: width-prefixed (8'b1010) and plain decimal in step/slice positions
+(integer_literal) @number
+(dec_integer)     @number
+
+; ── Operators ─────────────────────────────────────────────────────────────────
+
+(not_op) @operator
+":="     @operator
+"=="     @operator
+"+"      @operator
+
+; ── Punctuation ───────────────────────────────────────────────────────────────
+
+[ "{" "}" "(" ")" "[" "]" ] @punctuation.bracket
+[ "," ";" ":" ]             @punctuation.delimiter

--- a/tools/zed/languages/transactions/config.toml
+++ b/tools/zed/languages/transactions/config.toml
@@ -1,0 +1,4 @@
+name = "Transactions"
+grammar = "transactions"
+path_suffixes = ["tx"]
+line_comments = ["// "]

--- a/tools/zed/languages/transactions/highlights.scm
+++ b/tools/zed/languages/transactions/highlights.scm
@@ -1,0 +1,26 @@
+; ── Comments ──────────────────────────────────────────────────────────────────
+
+; Directive comment lines: // ARGS: ...  or  // RETURN: ...
+; Highlighted as a keyword so they stand out from plain comments.
+(directive_comment) @keyword.control
+
+; Plain comment: // ...
+(comment) @comment
+
+; ── Keywords ──────────────────────────────────────────────────────────────────
+
+"trace" @keyword.control
+
+; ── Transactions ──────────────────────────────────────────────────────────────
+
+; Function name in a transaction call
+(transaction function: (identifier) @function.call)
+
+; ── Literals ──────────────────────────────────────────────────────────────────
+
+(integer_literal) @number
+
+; ── Punctuation ───────────────────────────────────────────────────────────────
+
+[ "{" "}" "(" ")" ] @punctuation.bracket
+[ "," ";" ]         @punctuation.delimiter


### PR DESCRIPTION
(This is purely for fun) I am trying to migrate away from VS Code and instead use the Zed editor, which only supports Tree-Sitter for syntax highlighting as opposed to VS Code's TextMate format, so this allows for syntax highlighting in Zed.