### PR TITLE
[BI, Monitor] Generate random `BitVecValue`s when waveform value contains `X`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,28 +90,28 @@ jobs:
         # uv's warning messages about the formatter being experimental
         run: uv format --check --preview-features format      
 
-  benchmark:
-    name: Performance Benchmarks
-    runs-on: ubuntu-24.04
-    timeout-minutes: 30
+  # benchmark:
+  #   name: Performance Benchmarks
+  #   runs-on: ubuntu-24.04
+  #   timeout-minutes: 30
 
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Fetch all history to access baseline
-      - uses: ./.github/actions/setup-test-environment
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install hyperfine
-        run: |
-          wget https://github.com/sharkdp/hyperfine/releases/download/v1.19.0/hyperfine_1.19.0_amd64.deb
-          sudo dpkg -i hyperfine_1.19.0_amd64.deb
-      - name: Build monitor (release)
-        run: cargo build --release --package protocols-monitor
-      - name: Run benchmarks
-        run: uv run scripts/benchmark_monitor.py
-      - name: Check for performance regressions
-        run: uv run scripts/check_performance_regression.py
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0  # Fetch all history to access baseline
+  #     - uses: ./.github/actions/setup-test-environment
+  #       with:
+  #         github_token: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Install hyperfine
+  #       run: |
+  #         wget https://github.com/sharkdp/hyperfine/releases/download/v1.19.0/hyperfine_1.19.0_amd64.deb
+  #         sudo dpkg -i hyperfine_1.19.0_amd64.deb
+  #     - name: Build monitor (release)
+  #       run: cargo build --release --package protocols-monitor
+  #     - name: Run benchmarks
+  #       run: uv run scripts/benchmark_monitor.py
+  #     - name: Check for performance regressions
+  #       run: uv run scripts/check_performance_regression.py
 
 
   verilog:

--- a/bi/Cargo.toml
+++ b/bi/Cargo.toml
@@ -17,3 +17,4 @@ patronus.workspace = true
 wellen = "0.19.0"
 log = "0.4.27"
 rustc-hash.workspace = true
+rand = "0.9"

--- a/bi/Cargo.toml
+++ b/bi/Cargo.toml
@@ -17,4 +17,5 @@ patronus.workspace = true
 wellen = "0.19.0"
 log = "0.4.27"
 rustc-hash.workspace = true
-rand = "0.9"
+# There are dependency issues if we use rand v0.10, so we pin rand to 0.9 for now
+rand = "0.9"    

--- a/bi/src/signal_trace.rs
+++ b/bi/src/signal_trace.rs
@@ -7,8 +7,9 @@ use crate::Instance;
 use baa::BitVecValue;
 use protocols::design::Design;
 use protocols::ir::SymbolId;
+use rand::SeedableRng;
 use rustc_hash::FxHashMap;
-use wellen::{Hierarchy, SignalRef, TimescaleUnit};
+use wellen::{Hierarchy, SignalEncoding, SignalRef, TimescaleUnit};
 
 /// The result of advancing the clock cycle by one step
 #[derive(Debug, PartialEq)]
@@ -323,11 +324,16 @@ impl SignalTrace for WaveSignalTrace {
         // (represented as a bit-string)
         let bit_str = self.get_value(*signal_ref, self.time_step);
 
-        BitVecValue::from_bit_str(&bit_str).unwrap_or_else(|err| {
-            panic!(
-                "Unable to convert bit-string {bit_str} to BitVecValue, {:?}",
-                err
-            )
+        BitVecValue::from_bit_str(&bit_str).unwrap_or_else(|_| {
+            // If the bit-string can't be converted into a BitVecValue
+            // (e.g. because the waveform contains "x"), generate
+            // a random value of the appropriate bit-width.
+            let bitwidth = match self.wave.hierarchy().get_signal_tpe(*signal_ref) {
+                Some(SignalEncoding::BitVector(width)) => width.get(),
+                _ => panic!("Expected a bit-vector signal for key {:?}", key),
+            };
+            let mut rng = rand::rngs::SmallRng::seed_from_u64(0);
+            BitVecValue::random(&mut rng, bitwidth)
         })
     }
 

--- a/monitor/Cargo.toml
+++ b/monitor/Cargo.toml
@@ -19,4 +19,5 @@ log = "0.4.27"
 stdext = "0.3"
 rustc-hash.workspace = true
 anyhow = "1.0.100"
+# There are dependency issues if we use rand v0.10, so we pin rand to 0.9 for now
 rand = "0.9"

--- a/monitor/Cargo.toml
+++ b/monitor/Cargo.toml
@@ -19,3 +19,4 @@ log = "0.4.27"
 stdext = "0.3"
 rustc-hash.workspace = true
 anyhow = "1.0.100"
+rand = "0.9"

--- a/monitor/src/signal_trace.rs
+++ b/monitor/src/signal_trace.rs
@@ -8,8 +8,9 @@ use anyhow::Context;
 use baa::BitVecValue;
 use protocols::design::Design;
 use protocols::ir::SymbolId;
+use rand::SeedableRng;
 use rustc_hash::FxHashMap;
-use wellen::{Hierarchy, SignalRef};
+use wellen::{Hierarchy, SignalEncoding, SignalRef};
 
 /// The result of advancing the clock cycle by one step
 #[derive(Debug)]
@@ -449,11 +450,16 @@ impl SignalTrace for WaveSignalTrace {
         // (represented as a bit-string)
         let bit_str = self.get_value(*signal_ref, self.time_step);
 
-        Ok(BitVecValue::from_bit_str(&bit_str).unwrap_or_else(|err| {
-            panic!(
-                "Unable to convert bit-string {bit_str} to BitVecValue, {:?}",
-                err
-            )
+        Ok(BitVecValue::from_bit_str(&bit_str).unwrap_or_else(|_| {
+            // If the bit-string can't be converted into a BitVecValue
+            // (e.g. because the waveform contains "x"), generate
+            // a random value of the appropriate bit-width.
+            let bitwidth = match self.wave.hierarchy().get_signal_tpe(*signal_ref) {
+                Some(SignalEncoding::BitVector(width)) => width.get(),
+                _ => panic!("Expected a bit-vector signal for key {:?}", key),
+            };
+            let mut rng = rand::rngs::SmallRng::seed_from_u64(0);
+            BitVecValue::random(&mut rng, bitwidth)
         }))
     }
 }


### PR DESCRIPTION
Small changes to `bi` and `monitor` to generate random `BitVecValue`s (with a fixed seed) when a waveform value contains `X` and cannot be parsed directly. (This is useful for the ongoing Wishbone case study in the `ethmac` branch.)

Also commented out the performance benchmark tasks in CI for now, as discussed on Slack.