### PR TITLE
ir: add SymbolKind

### DIFF
--- a/monitor/src/axi_experiment.rs
+++ b/monitor/src/axi_experiment.rs
@@ -4,7 +4,7 @@ mod tests {
     use crate::signal_trace::{SignalTrace, StepResult, WaveSignalTrace};
     use baa::BitVecOps;
     use protocols::design::Design;
-    use protocols::ir::{Dir, Field, SymbolTable, Type};
+    use protocols::ir::{Dir, Field, SymbolKind, SymbolTable, Type};
     use rustc_hash::FxHashMap;
 
     fn axi_experiment_helper(waveform_file: &str, expected_values: Vec<u64>) {
@@ -12,14 +12,25 @@ mod tests {
         let mut symbol_table = SymbolTable::default();
 
         // Add symbols to the symbol table and get their IDs
-        let valid_id =
-            symbol_table.add_without_parent("m_axis_tvalid".to_string(), Type::BitVec(1));
-        let ready_id =
-            symbol_table.add_without_parent("m_axis_tready".to_string(), Type::BitVec(1));
-        let data_id = symbol_table.add_without_parent("m_axis_tdata".to_string(), Type::BitVec(8));
+        let valid_id = symbol_table.add_without_parent(
+            "m_axis_tvalid".to_string(),
+            Type::BitVec(1),
+            SymbolKind::InPort,
+        );
+        let ready_id = symbol_table.add_without_parent(
+            "m_axis_tready".to_string(),
+            Type::BitVec(1),
+            SymbolKind::OutPort,
+        );
+        let data_id = symbol_table.add_without_parent(
+            "m_axis_tdata".to_string(),
+            Type::BitVec(8),
+            SymbolKind::InPort,
+        );
 
         // Create a dummy SymbolId for the design itself
-        let design_id = symbol_table.add_without_parent("AXIS".to_string(), Type::Unknown);
+        let design_id =
+            symbol_table.add_without_parent("AXIS".to_string(), Type::Unknown, SymbolKind::Dut);
 
         // Create the Design for AXIS
         let axis_design = Design {

--- a/protocols/src/diagnostic.rs
+++ b/protocols/src/diagnostic.rs
@@ -558,8 +558,8 @@ mod tests {
     #[test]
     fn test_emit_diagnostic() {
         let mut symbols = SymbolTable::default();
-        let a = symbols.add_without_parent("a".to_string(), Type::BitVec(32));
-        let b = symbols.add_without_parent("b".to_string(), Type::BitVec(32));
+        let a = symbols.add_without_parent("a".to_string(), Type::BitVec(32), SymbolKind::InPort);
+        let b = symbols.add_without_parent("b".to_string(), Type::BitVec(32), SymbolKind::InPort);
 
         let mut tr = Transaction::new("test_transaction".to_string());
         let one_expr = tr.e(Expr::Const(BitVecValue::from_u64(1, 1)));

--- a/protocols/src/ir.rs
+++ b/protocols/src/ir.rs
@@ -268,6 +268,14 @@ pub enum Type {
     Unknown,
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum SymbolKind {
+    Dut,
+    InPort,
+    OutPort,
+    Arg,
+}
+
 impl Type {
     /// Checks whether two types are *equivalent*,
     /// i.e. if two bit-vector types have the same length,
@@ -525,7 +533,7 @@ impl std::fmt::Display for SymbolTable {
 }
 
 impl SymbolTable {
-    pub fn add_without_parent(&mut self, name: String, tpe: Type) -> SymbolId {
+    pub fn add_without_parent(&mut self, name: String, tpe: Type, kind: SymbolKind) -> SymbolId {
         assert!(
             !name.contains('.'),
             "hierarchical names need to be handled externally"
@@ -533,6 +541,7 @@ impl SymbolTable {
         let entry = SymbolTableEntry {
             name,
             tpe,
+            kind,
             parent: None,
         };
         let lookup_name = entry.full_name(self);
@@ -563,23 +572,28 @@ impl SymbolTable {
             "hierarchical names need to be handled externally"
         );
 
-        let existing_pin: Option<&Field>;
-
-        if let Type::Struct(structid) = self.entries[parent].tpe() {
+        let existing_pin = if let Type::Struct(structid) = self.entries[parent].tpe() {
             let fields = self.structs[structid].pins();
-            existing_pin = fields.iter().find(|field| field.name == name);
+            fields.iter().find(|field| field.name == name)
         } else {
-            existing_pin = None;
-        }
+            None
+        };
 
-        let pin_type = match existing_pin {
+        let tpe = match existing_pin {
             Some(pin) => pin.tpe(),
-            None => Type::Unknown,
+            None => todo!("deal with parent not being a struct"),
+        };
+
+        let kind = match existing_pin.map(|p| p.dir) {
+            Some(Dir::In) => SymbolKind::InPort,
+            Some(Dir::Out) => SymbolKind::OutPort,
+            None => todo!("deal with parent not being a struct"),
         };
 
         let entry = SymbolTableEntry {
             name,
-            tpe: pin_type,
+            tpe,
+            kind,
             parent: Some(parent),
         };
         let lookup_name = entry.full_name(self);
@@ -685,6 +699,7 @@ impl Index<&Arg> for SymbolTable {
 pub struct SymbolTableEntry {
     name: String,
     tpe: Type,
+    kind: SymbolKind,
     /// Used to compute the fully qualified name.
     parent: Option<SymbolId>,
 }
@@ -716,6 +731,13 @@ impl SymbolTableEntry {
         }
         name
     }
+
+    pub fn is_port(&self) -> bool {
+        matches!(self.kind, SymbolKind::InPort | SymbolKind::OutPort)
+    }
+    pub fn is_arg(&self) -> bool {
+        matches!(self.kind, SymbolKind::Arg)
+    }
 }
 
 #[cfg(test)]
@@ -729,9 +751,10 @@ mod tests {
 
         // 1) declare symbols
         let mut symbols = SymbolTable::default();
-        let a = symbols.add_without_parent("a".to_string(), Type::BitVec(32));
-        let b: SymbolId = symbols.add_without_parent("b".to_string(), Type::BitVec(32));
-        let s = symbols.add_without_parent("s".to_string(), Type::BitVec(32));
+        let a = symbols.add_without_parent("a".to_string(), Type::BitVec(32), SymbolKind::Arg);
+        let b: SymbolId =
+            symbols.add_without_parent("b".to_string(), Type::BitVec(32), SymbolKind::Arg);
+        let s = symbols.add_without_parent("s".to_string(), Type::BitVec(32), SymbolKind::Arg);
         assert_eq!(symbols["s"], symbols[s]);
 
         // declare Adder struct
@@ -743,7 +766,11 @@ mod tests {
                 Field::new("s".to_string(), Dir::Out, Type::BitVec(32)),
             ],
         );
-        let dut = symbols.add_without_parent("dut".to_string(), Type::Struct(add_struct));
+        let dut = symbols.add_without_parent(
+            "dut".to_string(),
+            Type::Struct(add_struct),
+            SymbolKind::Dut,
+        );
         let dut_a = symbols.add_with_parent("a".to_string(), dut);
         let dut_b = symbols.add_with_parent("b".to_string(), dut);
         let dut_s = symbols.add_with_parent("s".to_string(), dut);
@@ -783,8 +810,8 @@ mod tests {
 
         // 1) declare symbols
         let mut symbols = SymbolTable::default();
-        let ii = symbols.add_without_parent("ii".to_string(), Type::BitVec(32));
-        let oo = symbols.add_without_parent("oo".to_string(), Type::BitVec(32));
+        let ii = symbols.add_without_parent("ii".to_string(), Type::BitVec(32), SymbolKind::Arg);
+        let oo = symbols.add_without_parent("oo".to_string(), Type::BitVec(32), SymbolKind::Arg);
         assert_eq!(symbols["oo"], symbols[oo]);
 
         // declare DUT struct
@@ -798,7 +825,11 @@ mod tests {
             ],
         );
 
-        let dut = symbols.add_without_parent("dut".to_string(), Type::Struct(dut_struct));
+        let dut = symbols.add_without_parent(
+            "dut".to_string(),
+            Type::Struct(dut_struct),
+            SymbolKind::Dut,
+        );
         let dut_ii = symbols.add_with_parent("ii".to_string(), dut);
         let dut_go = symbols.add_with_parent("go".to_string(), dut);
         let dut_done = symbols.add_with_parent("done".to_string(), dut);

--- a/protocols/src/ir.rs
+++ b/protocols/src/ir.rs
@@ -273,7 +273,7 @@ pub enum SymbolKind {
     Dut,
     InPort,
     OutPort,
-    Arg,
+    Arg(u16),
 }
 
 impl Type {
@@ -735,8 +735,12 @@ impl SymbolTableEntry {
     pub fn is_port(&self) -> bool {
         matches!(self.kind, SymbolKind::InPort | SymbolKind::OutPort)
     }
-    pub fn is_arg(&self) -> bool {
-        matches!(self.kind, SymbolKind::Arg)
+    pub fn as_arg_index(&self) -> Option<usize> {
+        if let SymbolKind::Arg(index) = self.kind {
+            Some(index as usize)
+        } else {
+            None
+        }
     }
 }
 
@@ -751,10 +755,10 @@ mod tests {
 
         // 1) declare symbols
         let mut symbols = SymbolTable::default();
-        let a = symbols.add_without_parent("a".to_string(), Type::BitVec(32), SymbolKind::Arg);
+        let a = symbols.add_without_parent("a".to_string(), Type::BitVec(32), SymbolKind::Arg(0));
         let b: SymbolId =
-            symbols.add_without_parent("b".to_string(), Type::BitVec(32), SymbolKind::Arg);
-        let s = symbols.add_without_parent("s".to_string(), Type::BitVec(32), SymbolKind::Arg);
+            symbols.add_without_parent("b".to_string(), Type::BitVec(32), SymbolKind::Arg(1));
+        let s = symbols.add_without_parent("s".to_string(), Type::BitVec(32), SymbolKind::Arg(2));
         assert_eq!(symbols["s"], symbols[s]);
 
         // declare Adder struct
@@ -810,8 +814,8 @@ mod tests {
 
         // 1) declare symbols
         let mut symbols = SymbolTable::default();
-        let ii = symbols.add_without_parent("ii".to_string(), Type::BitVec(32), SymbolKind::Arg);
-        let oo = symbols.add_without_parent("oo".to_string(), Type::BitVec(32), SymbolKind::Arg);
+        let ii = symbols.add_without_parent("ii".to_string(), Type::BitVec(32), SymbolKind::Arg(0));
+        let oo = symbols.add_without_parent("oo".to_string(), Type::BitVec(32), SymbolKind::Arg(1));
         assert_eq!(symbols["oo"], symbols[oo]);
 
         // declare DUT struct

--- a/protocols/src/parser.rs
+++ b/protocols/src/parser.rs
@@ -255,9 +255,11 @@ impl ParserContext<'_> {
                                 .struct_id_from_name(path_id_2)
                                 .ok_or_else(|| format!("Undefined struct: {}", path_id_2))?;
                             let dut_struct = self.st[struct_id].clone();
-                            let dut_symbol_id = self
-                                .st
-                                .add_without_parent(path_id_1.to_string(), Type::Struct(struct_id));
+                            let dut_symbol_id = self.st.add_without_parent(
+                                path_id_1.to_string(),
+                                Type::Struct(struct_id),
+                                SymbolKind::Dut,
+                            );
                             self.tr.type_param = Some(dut_symbol_id);
                             for pin in dut_struct.pins() {
                                 let pin_name = pin.name().to_string();
@@ -503,7 +505,9 @@ impl ParserContext<'_> {
                     )?;
                     let id = id_pair.as_str();
                     let tpe = self.parse_type(tpe_pair)?;
-                    let symbol_id = self.st.add_without_parent(id.to_string(), tpe);
+                    let symbol_id =
+                        self.st
+                            .add_without_parent(id.to_string(), tpe, SymbolKind::Arg);
                     let arg = Arg::new(symbol_id);
                     args.push(arg);
                 }

--- a/protocols/src/parser.rs
+++ b/protocols/src/parser.rs
@@ -289,7 +289,21 @@ impl ParserContext<'_> {
                             &arglist_pair,
                             "Expected argument list",
                         )?;
-                        self.tr.args = self.parse_arglist(arg_rules)?;
+                        let raw_args = self.parse_arglist(arg_rules)?;
+
+                        // add raw arguments to symbol table
+                        self.tr.args = raw_args
+                            .into_iter()
+                            .enumerate()
+                            .map(|(index, (name, tpe))| {
+                                let symbol_id = self.st.add_without_parent(
+                                    name,
+                                    tpe,
+                                    SymbolKind::Arg(index as u16),
+                                );
+                                Arg::new(symbol_id)
+                            })
+                            .collect();
                     } else {
                         self.tr.args = Vec::new();
                     }
@@ -487,7 +501,10 @@ impl ParserContext<'_> {
         Ok(Stmt::IfElse(expr_id, if_block, else_block))
     }
 
-    fn parse_arglist(&mut self, pair: pest::iterators::Pair<Rule>) -> Result<Vec<Arg>, String> {
+    fn parse_arglist(
+        &mut self,
+        pair: pest::iterators::Pair<Rule>,
+    ) -> Result<Vec<(String, Type)>, String> {
         let mut args = Vec::new();
         for inner_pair in pair.into_inner() {
             match inner_pair.as_rule() {
@@ -503,13 +520,9 @@ impl ParserContext<'_> {
                         &inner_pair,
                         "Expected type in argument",
                     )?;
-                    let id = id_pair.as_str();
+                    let id = id_pair.as_str().to_string();
                     let tpe = self.parse_type(tpe_pair)?;
-                    let symbol_id =
-                        self.st
-                            .add_without_parent(id.to_string(), tpe, SymbolKind::Arg);
-                    let arg = Arg::new(symbol_id);
-                    args.push(arg);
+                    args.push((id, tpe));
                 }
                 Rule::arglist => {
                     let mut nested_args = self.parse_arglist(inner_pair)?;

--- a/protocols/src/serialize.rs
+++ b/protocols/src/serialize.rs
@@ -517,8 +517,9 @@ pub mod tests {
 
         // 1) declare symbols
         let mut symbols = SymbolTable::default();
-        let a = symbols.add_without_parent("a".to_string(), Type::BitVec(32));
-        let b: SymbolId = symbols.add_without_parent("b".to_string(), Type::BitVec(32));
+        let a = symbols.add_without_parent("a".to_string(), Type::BitVec(32), SymbolKind::Arg);
+        let b: SymbolId =
+            symbols.add_without_parent("b".to_string(), Type::BitVec(32), SymbolKind::Arg);
         assert_eq!(symbols["b"], symbols[b]);
 
         // declare DUT struct (TODO: Fix struct)
@@ -529,7 +530,11 @@ pub mod tests {
                 Field::new("b".to_string(), Dir::In, Type::BitVec(32)),
             ],
         );
-        let dut = symbols.add_without_parent("dut".to_string(), Type::Struct(dut_struct));
+        let dut = symbols.add_without_parent(
+            "dut".to_string(),
+            Type::Struct(dut_struct),
+            SymbolKind::Dut,
+        );
         let dut_a = symbols.add_with_parent("a".to_string(), dut);
         assert_eq!(symbols["dut.a"], symbols[dut_a]);
 

--- a/protocols/src/serialize.rs
+++ b/protocols/src/serialize.rs
@@ -517,9 +517,9 @@ pub mod tests {
 
         // 1) declare symbols
         let mut symbols = SymbolTable::default();
-        let a = symbols.add_without_parent("a".to_string(), Type::BitVec(32), SymbolKind::Arg);
+        let a = symbols.add_without_parent("a".to_string(), Type::BitVec(32), SymbolKind::Arg(0));
         let b: SymbolId =
-            symbols.add_without_parent("b".to_string(), Type::BitVec(32), SymbolKind::Arg);
+            symbols.add_without_parent("b".to_string(), Type::BitVec(32), SymbolKind::Arg(1));
         assert_eq!(symbols["b"], symbols[b]);
 
         // declare DUT struct (TODO: Fix struct)

--- a/protocols/src/typecheck.rs
+++ b/protocols/src/typecheck.rs
@@ -404,10 +404,12 @@ mod tests {
     fn function_argument_test() {
         let mut handler = DiagnosticHandler::default();
         let mut symbols = SymbolTable::default();
-        let a = symbols.add_without_parent("a".to_string(), Type::BitVec(1));
-        let b: SymbolId = symbols.add_without_parent("b".to_string(), Type::BitVec(1));
-        let c: SymbolId = symbols.add_without_parent("c".to_string(), Type::BitVec(1));
-        let s = symbols.add_without_parent("s".to_string(), Type::BitVec(1));
+        let a = symbols.add_without_parent("a".to_string(), Type::BitVec(1), SymbolKind::Arg);
+        let b: SymbolId =
+            symbols.add_without_parent("b".to_string(), Type::BitVec(1), SymbolKind::Arg);
+        let c: SymbolId =
+            symbols.add_without_parent("c".to_string(), Type::BitVec(1), SymbolKind::Arg);
+        let s = symbols.add_without_parent("s".to_string(), Type::BitVec(1), SymbolKind::Arg);
         assert_eq!(symbols["s"], symbols[s]);
         let input =
             std::fs::read_to_string("tests/misc/func_arg_invalid.prot").expect("failed to load");

--- a/protocols/src/typecheck.rs
+++ b/protocols/src/typecheck.rs
@@ -287,6 +287,11 @@ pub fn type_check(
     handler: &mut DiagnosticHandler,
 ) -> anyhow::Result<()> {
     for (tr, st) in trs {
+        // debug sanity check to make sure the symbol table and the argument list are in sync
+        for (index, arg) in tr.args.iter().enumerate() {
+            debug_assert_eq!(st[arg].as_arg_index(), Some(index), "{}", st[arg].name());
+        }
+
         for expr_id in tr.expr_ids() {
             check_expr_types(tr, st, handler, &expr_id)?;
         }
@@ -404,12 +409,12 @@ mod tests {
     fn function_argument_test() {
         let mut handler = DiagnosticHandler::default();
         let mut symbols = SymbolTable::default();
-        let a = symbols.add_without_parent("a".to_string(), Type::BitVec(1), SymbolKind::Arg);
+        let a = symbols.add_without_parent("a".to_string(), Type::BitVec(1), SymbolKind::Arg(0));
         let b: SymbolId =
-            symbols.add_without_parent("b".to_string(), Type::BitVec(1), SymbolKind::Arg);
+            symbols.add_without_parent("b".to_string(), Type::BitVec(1), SymbolKind::Arg(1));
         let c: SymbolId =
-            symbols.add_without_parent("c".to_string(), Type::BitVec(1), SymbolKind::Arg);
-        let s = symbols.add_without_parent("s".to_string(), Type::BitVec(1), SymbolKind::Arg);
+            symbols.add_without_parent("c".to_string(), Type::BitVec(1), SymbolKind::InPort);
+        let s = symbols.add_without_parent("s".to_string(), Type::BitVec(1), SymbolKind::Arg(2));
         assert_eq!(symbols["s"], symbols[s]);
         let input =
             std::fs::read_to_string("tests/misc/func_arg_invalid.prot").expect("failed to load");


### PR DESCRIPTION
This adds a `kind` field to each symbol table entry, which allows us to tell directly from a SymbolId whether we are dealing with an argument or a port.