### PR TITLE
[wishbone] burst mode: ACK is independent of STB requirement

### DIFF
--- a/examples/wishbone/wishbone.prot
+++ b/examples/wishbone/wishbone.prot
@@ -130,13 +130,12 @@ prot read<self: Wishbone>(mask: u4, addr: u32, data: u32) {
 prot write_burst_const<self: Wishbone>(mask: u4, addr: u32, data: [u32]+) {
     // no RST
     self.RST := 1'b0;
+
     // constant burst cycle (in which case bte is don't care)
     self.CTI := 3'b001;
     self.BTE := X;
 
-    // in our simple version, we always drive cyc and stb together
     self.CYC := 1'b1;
-    self.STB := 1'b1;
 
     // we are writing
     self.WE := 1'b1;
@@ -146,6 +145,8 @@ prot write_burst_const<self: Wishbone>(mask: u4, addr: u32, data: [u32]+) {
     self.SEL := mask;
 
     for d in data {
+        // set STB for at least one cycle
+        self.STB := 1'b1;
         self.DAT_O := d;
 
         // indicate end of cycle for last item
@@ -156,6 +157,12 @@ prot write_burst_const<self: Wishbone>(mask: u4, addr: u32, data: [u32]+) {
         // wait for ack
         while self.ACK == 1'b0 {
             step();
+            // after the first cycle, STB does not have to remain at one
+            // OBSERVATION 4.00:
+            // "[The server] can use the [CTI_I()] signals to determine the response for the next cycle.
+            //  But it cannot determine the state of [STB_I] for the next cycle,
+            //  therefore it must generate the response independent of [STB_I]."
+            self.STB := X;
         }
 
         // acknowledge is now true for one cycle

--- a/interp/src/main.rs
+++ b/interp/src/main.rs
@@ -61,6 +61,11 @@ struct Cli {
     /// Skips the static checks for step/fork errors.
     #[arg(long)]
     skip_static_step_fork_checks: bool,
+
+    /// Optimize the underlying transition system before simulation.
+    /// This might change the combinational dependencies.
+    #[arg(long)]
+    simplify_rtl: bool,
 }
 
 /// Examples (enables all tracing logs):
@@ -123,6 +128,7 @@ fn main() -> anyhow::Result<()> {
         cli.module,
         protocols_handler,
         cli.skip_static_step_fork_checks,
+        cli.simplify_rtl,
     )?;
 
     // Nikil says we have to do this step in order to convert

--- a/protocols/src/errors.rs
+++ b/protocols/src/errors.rs
@@ -736,34 +736,11 @@ impl DiagnosticEmitter {
                 );
             }
             EvaluationError::ForbiddenPortRead {
-                port_name,
                 unassigned_inputs,
                 expr_id,
+                ..
             } => {
-                let input_names: Vec<_> = unassigned_inputs
-                    .iter()
-                    .map(|(name, _)| format!("'{}'", name))
-                    .collect();
-                // Inputs with no stmt_id were never explicitly assigned (implicit DontCare at initialization)
-                let implicit_names: Vec<_> = unassigned_inputs
-                    .iter()
-                    .filter(|(_, stmt_id)| stmt_id.is_none())
-                    .map(|(name, _)| format!("'{}'", name))
-                    .collect();
-                let implicit_note = if implicit_names.is_empty() {
-                    String::new()
-                } else {
-                    format!(
-                        " ({} initialized to DontCare and were never assigned a concrete value)",
-                        implicit_names.join(", ")
-                    )
-                };
-                let main_message = format!(
-                    "Output '{}' depends on input(s) {} which do not have assigned values{}",
-                    port_name,
-                    input_names.join(", "),
-                    implicit_note
-                );
+                let main_message = format!("{error}");
                 let stmt_labels: Vec<_> = unassigned_inputs
                     .iter()
                     .filter_map(|(name, stmt_id)| {

--- a/protocols/src/setup.rs
+++ b/protocols/src/setup.rs
@@ -63,8 +63,13 @@ pub fn setup_test_environment(
     top_module: Option<String>,
     handler: &mut DiagnosticHandler,
     skip_static_step_fork_checks: bool,
+    simplify_rtl: bool,
 ) -> anyhow::Result<TestEnv> {
-    let (ctx, sys) = create_sim_context(verilog_paths, top_module);
+    let (mut ctx, mut sys) = create_sim_context(verilog_paths, top_module);
+    if simplify_rtl {
+        patronus::system::transform::replace_anonymous_inputs_with_zero(&mut ctx, &mut sys);
+        patronus::system::transform::simplify_expressions(&mut ctx, &mut sys);
+    }
     let parsed = frontend(transaction_filename, handler, skip_static_step_fork_checks)?;
     Ok((parsed, ctx, sys))
 }


### PR DESCRIPTION
Here is the section from the Wishbone spec:

```
OBSERVATION 4.00
To avoid the inherent wait state in synchronous termination schemes, the SERVER must generate the response as soon as possible (i.e. the next cycle). It can use the [CTI_I()] signals to determine the response for the next cycle. But it cannot determine the state of [STB_I] for the next cycle, therefore it must generate the response independent of [STB_I].
```

I have been trying to incorporate this rule into our protocol by setting `STB` to `X` while waiting for `ACK` to become high.

However, this triggers the following error in the interpreter:
```
> cargo interp  --transactions examples/wishbone/4.8_constant_address_burst.tx --verilog examples/wishbone/rtl/dut.v examples/wishbone/rtl/tb.v --module tb --protocol examples/wishbone/wishbone.prot 

error: Output 'self.ACK' depends on input(s) 'self.STB' which do not have assigned values
    ┌─ examples/wishbone/wishbone.prot:158:15
    │
158 │         while self.ACK == 1'b0 {
    │               ^^^^^^^^ Output 'self.ACK' depends on input(s) 'self.STB' which do not have assigned values
    ·
165 │             self.STB := X;
    │             ^^^^^^^^^^^^^^ 'self.STB' assigned DontCare here

Trace 0 execution failed.
```

So it seems like `ACK` in the RTL we have actually (sometimes) depends on `STB`.
Here is a simplified version of the expression that defines ACK:
```
OR(
  // if any of these are true, then there isn't really a dependency on STB
  eq(dut.count, 20'x00000),
  dut.basesoc_ram_bus_ack,
  dut.wishbone2csr_state,
  
  // this sub expression is directly dependent on STB and CYC
  AND(
    CYC,
    eq(ADR[29:0], 30'x34000000),
    STB,
    ite(WE,
       // write (check that fifo is not full)
       AND(
         eq(dut.testfifotransceiver_state, 2'b10)
         not(eq(dut.fifo_tx_level, 4'b1000))),
       // read (check that fifo is not empty)
       AND(
         eq(dut.testfifotransceiver_state, 2'b01)
         not(eq(dut.fifo_rx_level, 4'b0000)))
     )
   )
 )
```

Now the big question is: Who is to blame?
- My interpretation of the wishbone spec?
- Is our combinational dependency analysis too coarse?
- Is the RTL wrong?
