### PR TITLE
Serialize Automata IR to DOT file for graphviz

### DIFF
--- a/protocols/src/frontend/serialize.rs
+++ b/protocols/src/frontend/serialize.rs
@@ -5,6 +5,7 @@
 // author: Francis Pham <fdp25@cornell.edu>
 
 use std::io::Write;
+use std::ops::Index;
 
 use baa::{BitVecOps, BitVecValue};
 use itertools::Itertools;
@@ -141,26 +142,29 @@ pub fn serialize_args_mapping(
         .join("\n")
 }
 
-/// Pretty-prints an `Expression` (identified by its `ExprId`) using the current
-/// `Transaction` and `SymbolTable`
-pub fn serialize_expr(tr: &Protocol, st: &SymbolTable, expr_id: &ExprId) -> String {
-    match &tr[expr_id] {
+/// Pretty-prints an `Expression` (identified by its `ExprId`)
+/// from any expression store that can index by `ExprId`.
+pub fn serialize_expr<E>(exprs: &E, st: &SymbolTable, expr_id: &ExprId) -> String
+where
+    E: Index<ExprId, Output = Expr>,
+{
+    match &exprs[*expr_id] {
         Expr::Const(val) => val.to_u64().unwrap().to_string(),
         Expr::Sym(symid) => st[symid].full_name(st),
         Expr::DontCare => "X".to_string(),
         Expr::IsLastIteration => "is_last()".to_string(),
         Expr::IterCount(width) => format!("iter_count::<u{width}>()"),
         Expr::Unary(unary_op, expr_id) => {
-            let e = serialize_expr(tr, st, expr_id);
+            let e = serialize_expr(exprs, st, expr_id);
             format!("{}({})", unary_op, e)
         }
         Expr::Binary(op, lhs, rhs) => {
-            let e1 = serialize_expr(tr, st, lhs);
-            let e2 = serialize_expr(tr, st, rhs);
+            let e1 = serialize_expr(exprs, st, lhs);
+            let e2 = serialize_expr(exprs, st, rhs);
             format!("{e1} {op} {e2}")
         }
         Expr::Slice(expr, idx1, idx2) => {
-            let e = serialize_expr(tr, st, expr);
+            let e = serialize_expr(exprs, st, expr);
             let i = idx1.to_string();
             if *idx2 == *idx1 {
                 format!("{}[{}]", e, i)

--- a/protocols/src/ir/graphviz.rs
+++ b/protocols/src/ir/graphviz.rs
@@ -1,0 +1,120 @@
+use crate::frontend::serialize::serialize_expr;
+use crate::frontend::symbol::SymbolTable;
+use crate::ir::proto_graph::{Op, ProtoGraph};
+
+/// generate a DOT file for graphviz from the IR
+pub fn to_dot_string(protocol: &ProtoGraph, symbols: &SymbolTable) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "digraph \"{}\" {{\n",
+        escape_label(&protocol.name)
+    ));
+    out.push_str("  rankdir=LR;\n");
+    out.push_str("  node [shape=box];\n");
+    out.push_str("  entry_marker [shape=plain,label=\"ENTRY\"];\n");
+    out.push_str(&format!("  entry_marker -> {};\n", protocol.entry));
+
+    // emit one graphviz node per ir node
+    for (node_id, node) in protocol.nodes() {
+        let mut label_parts = vec![];
+
+        // collect action text into the node label
+        for action in node.action_iter() {
+            label_parts.push(format!(
+                "[{}] {}",
+                serialize_expr(protocol, symbols, &action.guard),
+                format_op(protocol, symbols, action.op)
+            ));
+        }
+
+        // generate a label from the actions (empty label if no actions)
+        out.push_str(&format!(
+            "  {} [label=\"{}\"];\n",
+            node_id,
+            escape_label(&label_parts.join("\\n"))
+        ));
+
+        // emit graph edges
+        for transition in node.transition_iter() {
+            let edge_label = if transition.consumes_step {
+                format!(
+                    "{} / step",
+                    serialize_expr(protocol, symbols, &transition.guard)
+                )
+            } else {
+                serialize_expr(protocol, symbols, &transition.guard)
+            };
+            out.push_str(&format!(
+                "  {} -> {} [label=\"{}\"];\n",
+                node_id,
+                transition.target,
+                escape_label(&edge_label)
+            ));
+        }
+    }
+
+    out.push_str("}\n");
+    out
+}
+
+/// simple serialization for ops. expressions are serialized using existing `serializer.rs` in the frontend
+fn format_op(
+    protocol: &ProtoGraph,
+    symbols: &SymbolTable,
+    op_id: crate::ir::proto_graph::OpId,
+) -> String {
+    match protocol.op(op_id) {
+        Op::Assign(symbol_id, expr_id) => format!(
+            "{} := {}",
+            symbols.full_name_from_symbol_id(symbol_id),
+            serialize_expr(protocol, symbols, expr_id)
+        ),
+        Op::AssertEq(lhs, rhs) => format!(
+            "assert_eq({}, {})",
+            serialize_expr(protocol, symbols, lhs),
+            serialize_expr(protocol, symbols, rhs)
+        ),
+        Op::Fork => "fork".to_string(),
+        Op::Done => "done".to_string(),
+    }
+}
+
+/// makes sure our digraph name is parseable by DOT
+fn escape_label(label: &str) -> String {
+    // preserve graphviz escapes like \n in labels, only escape quotes here
+    label.replace('"', "\\\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use crate::frontend::diagnostic::DiagnosticHandler;
+    use crate::frontend::parser::parse_file;
+    use crate::ir::lowering::lower_ast_to_ir;
+    use insta::Settings;
+
+    use super::*;
+
+    fn snap(name: &str, content: String) {
+        let mut settings = Settings::clone_current();
+        settings.set_snapshot_path(Path::new("../tests/snapshots"));
+        settings.bind(|| {
+            insta::assert_snapshot!(name, content);
+        });
+    }
+
+    #[test]
+    fn test_add_d1_dot_snapshot() {
+        let mut handler = DiagnosticHandler::default();
+        let parsed = parse_file("tests/adders/adder_d1/add_d1.prot", &mut handler).unwrap();
+        let (ast, symbols) = parsed
+            .into_iter()
+            .find(|(ast, _)| ast.name == "add")
+            .unwrap();
+        let ir = lower_ast_to_ir(ast);
+
+        let dot = to_dot_string(&ir, &symbols);
+        snap("ir_graphviz_add_d1", dot);
+    }
+}

--- a/protocols/src/ir/mod.rs
+++ b/protocols/src/ir/mod.rs
@@ -1,3 +1,4 @@
+pub mod graphviz;
 pub mod lowering;
 mod proto_graph;
 

--- a/protocols/src/tests/snapshots/protocols__ir__graphviz__tests__ir_graphviz_add_d1.snap
+++ b/protocols/src/tests/snapshots/protocols__ir__graphviz__tests__ir_graphviz_add_d1.snap
@@ -1,0 +1,29 @@
+---
+source: protocols/src/ir/graphviz.rs
+expression: content
+---
+digraph "add" {
+  rankdir=LR;
+  node [shape=box];
+  entry_marker [shape=plain,label="ENTRY"];
+  entry_marker -> node0;
+  node0 [label=""];
+  node0 -> node1 [label="1"];
+  node1 [label="[1] DUT.a := a"];
+  node1 -> node2 [label="1"];
+  node2 [label="[1] DUT.b := b"];
+  node2 -> node3 [label="1"];
+  node3 [label=""];
+  node3 -> node4 [label="1 / step"];
+  node4 [label="[1] DUT.a := X"];
+  node4 -> node5 [label="1"];
+  node5 [label="[1] DUT.b := X"];
+  node5 -> node6 [label="1"];
+  node6 [label="[1] assert_eq(s, DUT.s)"];
+  node6 -> node7 [label="1"];
+  node7 [label="[1] fork"];
+  node7 -> node8 [label="1"];
+  node8 [label=""];
+  node8 -> node9 [label="1 / step"];
+  node9 [label="[1] done"];
+}


### PR DESCRIPTION
- Wrote a very simple serializer for the IR. Right now, the file is called `graphviz.rs` but I don't know if I should change it to also be called `serialize.rs` (like in the frontend), or maybe `serialize_dot.rs` instead
- Expressions are serialized using the existing expression serializer Francis wrote way back when. Ops have a custom, but very simple serialization
- The DOT visualization is left to right with a clearly labelled start node, actions within each node (if there are any), and transitions as edges between nodes, labelled with their guard and `/ step` if they are a step-edge. Note that `[1]` denotes a guard of `1` (true). not sure if we should have a special serialization for `1/0` as `T/F`.
- Tested with a checked-in snapshot of the adder protocol, producing the following viz:

<img width="1151" height="64" alt="image" src="https://github.com/user-attachments/assets/e8a5143f-41bc-4793-ba01-e4f216be729c" />
- Since this new IR is quite simple, I expect this serialization code to be robust to when we start doing graph rewrites and tackle control flow as well. I foresee we may need to make some tweaks for formatting (maybe add colors, etc.) when graphs start to get larger 
