### PR TITLE
Graph Interpreter 

### DIFF
--- a/cli/src/bin/graph-interp.rs
+++ b/cli/src/bin/graph-interp.rs
@@ -1,0 +1,122 @@
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+use clap::Parser;
+use protocols::frontend::ast::Protocol;
+use protocols::frontend::diagnostic::DiagnosticHandler;
+use protocols::frontend::symbol::SymbolTable;
+use protocols::ir::graph_interpreter;
+use protocols::ir::lowering::lower_ast_to_ir;
+use protocols::setup::create_sim_context;
+use protocols::{Value, frontend, transaction_frontend};
+use rustc_hash::FxHashMap;
+
+#[derive(Parser, Debug)]
+struct Cli {
+    /// Paths to one or more Verilog (.v) files
+    #[arg(long, value_name = "VERILOG_FILES", value_delimiter = ' ', num_args = 1..)]
+    verilog: Vec<String>,
+
+    /// Path to a Protocol (.prot) file
+    #[arg(short, long, value_name = "PROTOCOLS_FILE")]
+    protocol: String,
+
+    /// Path to a Transactions (.tx) file
+    #[arg(short, long, value_name = "TRANSACTIONS_FILE")]
+    transactions: String,
+
+    /// Name of the top-level module (if one exists)
+    #[arg(short, long, value_name = "MODULE_NAME")]
+    module: Option<String>,
+
+    /// Skips the static checks for step/fork errors.
+    #[arg(long)]
+    skip_static_step_fork_checks: bool,
+}
+
+fn load_protocols(cli: &Cli) -> Vec<(Protocol, SymbolTable)> {
+    let mut handler = DiagnosticHandler::new(clap::ColorChoice::Never, false, true, false);
+    frontend(
+        &cli.protocol,
+        &mut handler,
+        cli.skip_static_step_fork_checks,
+    )
+    .unwrap()
+}
+
+fn load_traces(cli: &Cli, protos: &[(Protocol, SymbolTable)]) -> Vec<Vec<(String, Vec<Value>)>> {
+    let mut handler = DiagnosticHandler::new(clap::ColorChoice::Never, false, true, false);
+    transaction_frontend(&cli.transactions, protos.iter(), &mut handler).unwrap()
+}
+
+fn build_arg_map<'a>(
+    args: &'a [protocols::frontend::symbol::Arg],
+    symbols: &'a SymbolTable,
+    values: Vec<Value>,
+) -> FxHashMap<&'a str, Value> {
+    assert_eq!(args.len(), values.len(), "argument count mismatch");
+    args.iter()
+        .zip(values)
+        .map(|(arg, value)| (symbols[arg.symbol()].name(), value))
+        .collect()
+}
+
+fn print_panic_payload(payload: Box<dyn std::any::Any + Send>) {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        eprintln!("{message}");
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        eprintln!("{message}");
+    } else {
+        eprintln!("graph interpreter panicked");
+    }
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let protos = load_protocols(&cli);
+    let traces = load_traces(&cli, &protos);
+    let (ctx, sys) = create_sim_context(
+        cli.verilog.iter().map(|v| v.as_str()).collect(),
+        cli.module.clone(),
+    );
+
+    let graphs: FxHashMap<String, _> = protos
+        .iter()
+        .map(|(proto, symbols)| {
+            (
+                proto.name.clone(),
+                (lower_ast_to_ir(proto.clone()), symbols),
+            )
+        })
+        .collect();
+
+    let old_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        for (trace_index, trace) in traces.into_iter().enumerate() {
+            for (name, values) in trace {
+                let (graph, symbols) = graphs
+                    .get(&name)
+                    .unwrap_or_else(|| panic!("unknown protocol {name}"));
+                let args = build_arg_map(&graph.args, symbols, values);
+                graph_interpreter::interpret(
+                    graph,
+                    symbols,
+                    args,
+                    &ctx,
+                    &sys,
+                    // note that this creates a new interpreter for every transaction (even within one trace)
+                    // this might not be correct, but we will figure this out once we start working with supporting forks/multi-trace/multi-protocol
+                    // transactions
+                    patronus::sim::Interpreter::new(&ctx, &sys),
+                );
+            }
+            println!("trace {} executed successfully", trace_index);
+        }
+    }));
+    std::panic::set_hook(old_hook);
+
+    if let Err(payload) = result {
+        print_panic_payload(payload);
+        std::process::exit(101);
+    }
+}

--- a/justfile
+++ b/justfile
@@ -22,6 +22,10 @@ axis:
 adders:
   turnt --env interp $(find protocols/tests/adders -type f -name '*.tx') 
 
+# Only run graph-interpreter tests that are explicitly enabled
+graph_interp:
+  turnt --env graph_interp $(cat protocols/tests/graph_interp_allowlist.txt)
+
 # Only run interpreter tests for the ALU examples
 alus:
   turnt --env interp $(find protocols/tests/alus -type f -name '*.tx') 

--- a/protocols/src/frontend/ast.rs
+++ b/protocols/src/frontend/ast.rs
@@ -111,6 +111,19 @@ impl Protocol {
         }
     }
 
+    /// an empty Protocol AST with a given ProtocolContext `ctx` 
+    pub fn from_context(ctx: ProtocolContext) -> Self {
+        let mut stmts = PrimaryMap::new();
+        let block_id: StmtId = stmts.push(Stmt::Block(vec![]));
+        let stmt_loc: SecondaryMap<StmtId, (usize, usize, usize)> = SecondaryMap::new();
+        Self {
+            ctx,
+            body: block_id,
+            stmts,
+            stmt_loc,
+        }
+    }
+
     /// add a new expression to the transaction
     pub fn e(&mut self, expr: Expr) -> ExprId {
         self.ctx.exprs.push(expr)

--- a/protocols/src/frontend/ast.rs
+++ b/protocols/src/frontend/ast.rs
@@ -111,7 +111,7 @@ impl Protocol {
         }
     }
 
-    /// an empty Protocol AST with a given ProtocolContext `ctx` 
+    /// an empty Protocol AST with a given ProtocolContext `ctx`
     pub fn from_context(ctx: ProtocolContext) -> Self {
         let mut stmts = PrimaryMap::new();
         let block_id: StmtId = stmts.push(Stmt::Block(vec![]));

--- a/protocols/src/interpreter.rs
+++ b/protocols/src/interpreter.rs
@@ -392,54 +392,24 @@ impl<'a> Evaluator<'a> {
         }
 
         // Apply value to sim
-        if let Some(expr_ref) = self.input_mapping.get(symbol_id) {
-            match new_val {
-                ThreadInputValue::Concrete(bvv) => {
-                    // Always apply Concrete values immediately
-                    self.sim.set(*expr_ref, &bvv);
-                }
-                ThreadInputValue::DontCare => {
-                    // Check if any OTHER thread has Concrete for this pin
-                    let any_other_concrete =
-                        if let Some(per_thread_vals) = self.per_thread_input_vals.get(symbol_id) {
-                            per_thread_vals.iter().any(|(&other_idx, (other_val, _))| {
-                                other_idx != todo_idx
-                                    && matches!(other_val, ThreadInputValue::Concrete(_))
-                            })
-                        } else {
-                            false
-                        };
+        if self.input_mapping.contains_key(symbol_id) {
+            let any_other_concrete = if let Some(per_thread_vals) = self.per_thread_input_vals.get(symbol_id) {
+                per_thread_vals.iter().any(|(&other_idx, (other_val, _))| {
+                    other_idx != todo_idx && matches!(other_val, ThreadInputValue::Concrete(_))
+                })
+            } else {
+                false
+            };
 
-                    let symbol_name = self.st[*symbol_id].name();
-                    log::info!(
-                        "Applying DontCare for {} (todo_idx={}): any_other_concrete={}",
-                        symbol_name,
-                        todo_idx,
-                        any_other_concrete
-                    );
+            let symbol_name = self.st[*symbol_id].name();
+            log::info!(
+                "Applying value for {} (todo_idx={}): any_other_concrete={}",
+                symbol_name,
+                todo_idx,
+                any_other_concrete
+            );
 
-                    // If all other threads have DontCare, randomize
-                    if !any_other_concrete {
-                        let width = match self.st[*symbol_id].tpe() {
-                            Type::BitVec(w) => w,
-                            _ => panic!("Expected BitVec type for input"),
-                        };
-                        let random_val = BitVecValue::random(&mut self.rng, width);
-                        log::info!(
-                            "  Randomizing {} to {}",
-                            symbol_name,
-                            serialize_bitvec(&random_val, false)
-                        );
-                        self.sim.set(*expr_ref, &random_val);
-                    } else {
-                        log::info!(
-                            "  NOT randomizing {} (another thread has Concrete)",
-                            symbol_name
-                        );
-                    }
-                    // Otherwise do nothing - leave the Concrete value in place
-                }
-            }
+            self.write_input_value_to_sim(symbol_id, &new_val, !any_other_concrete);
         }
 
         Ok(())
@@ -581,7 +551,35 @@ impl<'a> Evaluator<'a> {
         self.sim.step();
     }
 
-    fn evaluate_expr(&mut self, expr_id: &ExprId) -> ExecutionResult<ExprValue> {
+    pub fn write_input_value_to_sim(
+        &mut self,
+        symbol_id: &SymbolId,
+        value: &ThreadInputValue,
+        randomize_dont_care: bool,
+    ) {
+        let expr_ref = *self
+            .input_mapping
+            .get(symbol_id)
+            .unwrap_or_else(|| panic!("expected input symbol {symbol_id}"));
+
+        match value {
+            ThreadInputValue::Concrete(bvv) => {
+                self.sim.set(expr_ref, bvv);
+            }
+            ThreadInputValue::DontCare => {
+                if randomize_dont_care {
+                    let width = match self.st[*symbol_id].tpe() {
+                        Type::BitVec(w) => w,
+                        _ => panic!("expected BitVec type for input {symbol_id}"),
+                    };
+                    let random_val = BitVecValue::random(&mut self.rng, width);
+                    self.sim.set(expr_ref, &random_val);
+                }
+            }
+        }
+    }
+
+    pub fn evaluate_expr(&mut self, expr_id: &ExprId) -> ExecutionResult<ExprValue> {
         let expr = &self.tr[expr_id];
         match expr {
             Expr::Const(bit_vec) => Ok(ExprValue::Concrete(bit_vec.clone())),

--- a/protocols/src/interpreter.rs
+++ b/protocols/src/interpreter.rs
@@ -393,13 +393,14 @@ impl<'a> Evaluator<'a> {
 
         // Apply value to sim
         if self.input_mapping.contains_key(symbol_id) {
-            let any_other_concrete = if let Some(per_thread_vals) = self.per_thread_input_vals.get(symbol_id) {
-                per_thread_vals.iter().any(|(&other_idx, (other_val, _))| {
-                    other_idx != todo_idx && matches!(other_val, ThreadInputValue::Concrete(_))
-                })
-            } else {
-                false
-            };
+            let any_other_concrete =
+                if let Some(per_thread_vals) = self.per_thread_input_vals.get(symbol_id) {
+                    per_thread_vals.iter().any(|(&other_idx, (other_val, _))| {
+                        other_idx != todo_idx && matches!(other_val, ThreadInputValue::Concrete(_))
+                    })
+                } else {
+                    false
+                };
 
             let symbol_name = self.st[*symbol_id].name();
             log::info!(

--- a/protocols/src/ir/graph_interpreter.rs
+++ b/protocols/src/ir/graph_interpreter.rs
@@ -1,0 +1,141 @@
+// Copyright 2026 Cornell University
+// released under MIT License
+// author: Nikil Shyamunder <nvs26@cornell.edu>
+
+use baa::BitVecOps;
+use patronus::expr::Context;
+use patronus::sim::Interpreter;
+use patronus::system::TransitionSystem;
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::Value;
+use crate::frontend::ast::Protocol;
+use crate::frontend::symbol::{SymbolId, SymbolTable};
+use crate::interpreter::{Evaluator, ExprValue, ThreadInputValue};
+use crate::ir::proto_graph::{Op, ProtoGraph};
+
+/// interpret a `ProtoGraph`
+pub fn interpret(
+    pg: &ProtoGraph,
+    st: &SymbolTable,
+    args: FxHashMap<&str, Value>,
+    ctx: &Context,
+    sys: &TransitionSystem,
+    sim: Interpreter,
+) {
+    // create a shell AST so we can reuse the existing simulator setup and expr evaluation
+    let shell = Protocol::from_context(pg.ctx.clone());
+    let mut evaluator = Evaluator::new(args, &shell, st, ctx, sys, sim);
+    evaluator.init_thread_inputs(0).unwrap();
+
+    let mut curr = pg.entry;
+    loop {
+        let node = &pg[curr];
+        let mut pending_inputs: FxHashMap<SymbolId, ThreadInputValue> = FxHashMap::default();
+        let mut assigned_inputs: FxHashSet<SymbolId> = FxHashSet::default();
+
+        // note: this is more of a wellformedness check than anything.
+        // even untriggered duplicate assigns to the same input in one node are rejected.
+        for action in node.action_iter() {
+            if let Op::Assign(symbol_id, _) = &pg[action.op]
+                && !assigned_inputs.insert(*symbol_id)
+            {
+                panic!("multiple assigns to input {symbol_id} in one node");
+            }
+        }
+
+        // first pass: buffer any triggered assigns
+        for action in node.action_iter() {
+            if let Op::Assign(symbol_id, expr_id) = &pg[action.op]
+                && evaluate_guard(&mut evaluator, action.guard)
+            {
+                let value = expr_to_input_value(&mut evaluator, expr_id);
+                pending_inputs.insert(*symbol_id, value);
+            }
+        }
+
+        // apply inputs from the buffer
+        for (symbol_id, value) in pending_inputs {
+            evaluator.write_input_value_to_sim(&symbol_id, &value, true);
+        }
+
+        // second pass: after applying buffered inputs, evaluate non-assign actions
+        let mut done_triggered = false;
+        for action in node.action_iter() {
+            if evaluate_guard(&mut evaluator, action.guard) {
+                match &pg[action.op] {
+                    Op::Assign(_, _) => {}
+                    Op::AssertEq(lhs, rhs) => {
+                        assert_eq_exprs(&mut evaluator, lhs, rhs);
+                    }
+                    Op::Fork => {}
+                    Op::Done => done_triggered = true,
+                }
+            }
+        }
+
+        let satisfied_transitions: Vec<_> = node
+            .transition_iter()
+            .filter(|transition| evaluate_guard(&mut evaluator, transition.guard))
+            .collect();
+
+        if done_triggered {
+            assert!(
+                satisfied_transitions.is_empty(),
+                "done triggered alongside a satisfied transition out of {curr}"
+            );
+            return;
+        }
+
+        if satisfied_transitions.is_empty() {
+            panic!("done not triggered though there are no satisfying transitions out of {curr}");
+        }
+
+        assert!(
+            satisfied_transitions.len() <= 1,
+            "multiple transitions simultaneously satisfied out of {curr}"
+        );
+
+        let transition = satisfied_transitions.into_iter().next().unwrap();
+
+        if transition.consumes_step {
+            evaluator.finalize_inputs_for_cycle();
+            evaluator.sim_step();
+        }
+
+        curr = transition.target;
+    }
+}
+
+fn evaluate_guard(evaluator: &mut Evaluator<'_>, expr_id: crate::frontend::ast::ExprId) -> bool {
+    match evaluator.evaluate_expr(&expr_id).unwrap() {
+        ExprValue::Concrete(bvv) => !bvv.is_zero(),
+        ExprValue::DontCare => panic!("guard evaluated to DontCare"),
+    }
+}
+
+fn expr_to_input_value(
+    evaluator: &mut Evaluator<'_>,
+    expr_id: &crate::frontend::ast::ExprId,
+) -> ThreadInputValue {
+    match evaluator.evaluate_expr(expr_id).unwrap() {
+        ExprValue::Concrete(bvv) => ThreadInputValue::Concrete(bvv),
+        ExprValue::DontCare => ThreadInputValue::DontCare,
+    }
+}
+
+fn assert_eq_exprs(
+    evaluator: &mut Evaluator<'_>,
+    lhs: &crate::frontend::ast::ExprId,
+    rhs: &crate::frontend::ast::ExprId,
+) {
+    let lhs = evaluator.evaluate_expr(lhs).unwrap();
+    let rhs = evaluator.evaluate_expr(rhs).unwrap();
+    match (lhs, rhs) {
+        (ExprValue::Concrete(lhs), ExprValue::Concrete(rhs)) => {
+            assert_eq!(lhs.width(), rhs.width(), "assert_eq width mismatch");
+            assert!(lhs.is_equal(&rhs), "assert_eq failed");
+        }
+        _ => panic!("assert_eq on DontCare"),
+    }
+}

--- a/protocols/src/ir/graph_interpreter.rs
+++ b/protocols/src/ir/graph_interpreter.rs
@@ -10,6 +10,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::Value;
 use crate::frontend::ast::Protocol;
+use crate::frontend::serialize::serialize_bitvec;
 use crate::frontend::symbol::{SymbolId, SymbolTable};
 use crate::interpreter::{Evaluator, ExprValue, ThreadInputValue};
 use crate::ir::proto_graph::{Op, ProtoGraph};
@@ -79,31 +80,32 @@ pub fn interpret(
             .filter(|transition| evaluate_guard(&mut evaluator, transition.guard))
             .collect();
 
-        if done_triggered {
-            assert!(
-                satisfied_transitions.is_empty(),
-                "done triggered alongside a satisfied transition out of {curr}"
-            );
-            return;
-        }
+        // FIXME: I don't know if this iff property is true
+        // if it is, there is no need for a done state
+        // likely it won't be, maybe with repeat/for_in
+        // for now, it's useful to sanity check straight-line code
+        assert!(
+            // done <==> no outgoing transitions are triggered
+            done_triggered && satisfied_transitions.is_empty()
+                || !done_triggered && !satisfied_transitions.is_empty(),
+            "done triggered alongside a satisfied transition out of {curr}"
+        );
 
-        if satisfied_transitions.is_empty() {
-            panic!("done not triggered though there are no satisfying transitions out of {curr}");
-        }
-
+        // this isn't an NFA
         assert!(
             satisfied_transitions.len() <= 1,
             "multiple transitions simultaneously satisfied out of {curr}"
         );
 
-        let transition = satisfied_transitions.into_iter().next().unwrap();
-
-        if transition.consumes_step {
-            evaluator.finalize_inputs_for_cycle();
-            evaluator.sim_step();
+        match satisfied_transitions.into_iter().next() {
+            Some(t) => {
+                if t.consumes_step {
+                    evaluator.sim_step();
+                }
+                curr = t.target;
+            }
+            None => break,
         }
-
-        curr = transition.target;
     }
 }
 
@@ -134,7 +136,12 @@ fn assert_eq_exprs(
     match (lhs, rhs) {
         (ExprValue::Concrete(lhs), ExprValue::Concrete(rhs)) => {
             assert_eq!(lhs.width(), rhs.width(), "assert_eq width mismatch");
-            assert!(lhs.is_equal(&rhs), "assert_eq failed");
+            assert!(
+                lhs.is_equal(&rhs),
+                "assert_eq failed: lhs={} rhs={}",
+                serialize_bitvec(&lhs, false),
+                serialize_bitvec(&rhs, false)
+            );
         }
         _ => panic!("assert_eq on DontCare"),
     }

--- a/protocols/src/ir/graphviz.rs
+++ b/protocols/src/ir/graphviz.rs
@@ -63,7 +63,7 @@ fn format_op(
     symbols: &SymbolTable,
     op_id: crate::ir::proto_graph::OpId,
 ) -> String {
-    match protocol.op(op_id) {
+    match &protocol[op_id] {
         Op::Assign(symbol_id, expr_id) => format!(
             "{} := {}",
             symbols.full_name_from_symbol_id(symbol_id),

--- a/protocols/src/ir/mod.rs
+++ b/protocols/src/ir/mod.rs
@@ -1,5 +1,5 @@
-pub mod graphviz;
 pub mod graph_interpreter;
+pub mod graphviz;
 pub mod lowering;
 mod proto_graph;
 

--- a/protocols/src/ir/mod.rs
+++ b/protocols/src/ir/mod.rs
@@ -1,4 +1,5 @@
 pub mod graphviz;
+pub mod graph_interpreter;
 pub mod lowering;
 mod proto_graph;
 

--- a/protocols/src/ir/proto_graph.rs
+++ b/protocols/src/ir/proto_graph.rs
@@ -125,10 +125,6 @@ impl ProtoGraph {
         self.nodes.iter()
     }
 
-    pub fn op(&self, op_id: OpId) -> &Op {
-        &self.ops[op_id]
-    }
-
     /// push an action `a` onto `node_id`
     pub fn push_action(&mut self, node_id: NodeId, a: Action) {
         self.nodes[node_id].actions.push(a);
@@ -198,6 +194,38 @@ impl Index<&ExprId> for ProtoGraph {
 
     fn index(&self, index: &ExprId) -> &Self::Output {
         &self.ctx[index]
+    }
+}
+
+impl Index<NodeId> for ProtoGraph {
+    type Output = Node;
+
+    fn index(&self, index: NodeId) -> &Self::Output {
+        &self.nodes[index]
+    }
+}
+
+impl Index<&NodeId> for ProtoGraph {
+    type Output = Node;
+
+    fn index(&self, index: &NodeId) -> &Self::Output {
+        &self.nodes[*index]
+    }
+}
+
+impl Index<OpId> for ProtoGraph {
+    type Output = Op;
+
+    fn index(&self, index: OpId) -> &Self::Output {
+        &self.ops[index]
+    }
+}
+
+impl Index<&OpId> for ProtoGraph {
+    type Output = Op;
+
+    fn index(&self, index: &OpId) -> &Self::Output {
+        &self.ops[*index]
     }
 }
 

--- a/protocols/tests/adders/adder_d1/add_multitrace.graphout
+++ b/protocols/tests/adders/adder_d1/add_multitrace.graphout
@@ -1,0 +1,20 @@
+warning: Inferred RHS type as u32 from LHS type u32.
+   ┌─ adders/adder_d1/add_d1.prot:12:3
+   │
+12 │   DUT.a := X;
+   │   ^^^^^^^^^^^ Inferred RHS type as u32 from LHS type u32.
+
+warning: Inferred RHS type as u32 from LHS type u32.
+   ┌─ adders/adder_d1/add_d1.prot:13:3
+   │
+13 │   DUT.b := X;
+   │   ^^^^^^^^^^^ Inferred RHS type as u32 from LHS type u32.
+
+warning: Inferred RHS type as u32 from LHS type u32.
+   ┌─ adders/adder_d1/add_d1.prot:25:3
+   │
+25 │   DUT.b := X;
+   │   ^^^^^^^^^^^ Inferred RHS type as u32 from LHS type u32.
+
+trace 0 executed successfully
+assert_eq failed: lhs=10 rhs=9

--- a/protocols/tests/graph_interp_allowlist.txt
+++ b/protocols/tests/graph_interp_allowlist.txt
@@ -1,0 +1,1 @@
+protocols/tests/adders/adder_d1/add_multitrace.tx

--- a/protocols/tests/turnt.toml
+++ b/protocols/tests/turnt.toml
@@ -1,2 +1,8 @@
 [envs.interp]
 command = "cargo interp --color never --transactions {filename} {args}"
+output.out = "-"
+
+[envs.graph_interp]
+default = false
+command = "cargo run -q -p protocols-cli --bin graph-interp -- --transactions {filename} {args} 2>&1"
+output.graphout = "-"


### PR DESCRIPTION
Adds a simple graph interpreter for the ProtoGraph IR. 

**Semantics:**
- start at the entry node. there is a sticky assignment buffer that starts with all input pins as `DontCare`.
- first, go through the actions that correspond to assignments and update the buffer. Then reapply all pins with the updated values. Then evaluate all other actions. 
- then evaluate the transitions. 
- Note that all of these ordering decision (update assignments --> all other actions -->  transitions) stop mattering if we don't have combinational dependency issues, which I don't believe we aren't worrying about right now. 
- For now, there is a check that the done flag is raised if and only if there are no triggered transitions. This, i expect to stop working when we introduce repeat/for _ in loops, but as a sanity check I am keeping it for now. There is also a check that there are not multiple transitions triggered (non-determinism) - once again, this may be violated in the future but we will cross that bridge when we get there.
- The way of printing results is much simpler than the AST interpreter (just using assertions and panics for now, stripping the thread info that is non-deterministic in order for snapshots to stay the same over time). 

**Practical matters on engineering the graph interpreter:**
I went about this in a way in order to minimize code duplication between the AST interpreter and IR interpreter (by taking advantage of the common Patronus setup, simulator interface functions, and expression evaluation). The strategy is as follows: 
- In `ast.rs`, allow for the creation of an empty AST given a `ProtocolContext` wth a `from_context` constructor
- In `interpreter.rs` (the AST interpreter), make two functions public: apply simulator inputs and evaluate expressions. 
- In `graph_interpreter.rs`, create a an empty AST using the `from_context` constructor, then use those two public functions to evaluate expressions and drive inputs for the sake of the graph interpreter semantics, ignoring the rest of the capabilities of the AST interpreter.

The change surface ends up being quite small, which is nice, though there is some janky-ness involved I admit. If we feel this is two janky right now or wish to improve this in the future, I can address it now or we can file an issue respectively. I expect the best way to do this is to split the AST interpreter into the interpreter and a shim, and reuse that shim across the AST and graph interpreters. It's not clear to me how much extra work this will be. Additionally, I wish to avoid doing too much here if we end up switching to Patronus expressions.

**Testing:**
- Added CLI command to lower from `.prot` files all the way to the IR and serialize DOT files
- Added CLI command to interpreter from `.tx` at the graph IR level. 
- Set up a turnt environment for both of these. Because most tests will fail with turnt for now, I set up an `allowlist` which `just graph_interp` reads and uses to launch the allowlisted tests. This isn't in CI yet (though I can turn it on if we want). Also, only one test is allowlisted for now. I will start trying more tests, but I wanted to get this PR up first. 
- For now, I do not think we should use turnt for the serialization tests (it's going to be one extra file in the test directory for every `.prot` + a second allowlist for .prot fles), and serialization tests have historically been done with insta which I think is fine, and insta allows us to have these in a separate directory. The add_d1.prot file is already in the insta snapshot tests. Once again, will start adding more tests to the turnt allowlist/insta tests as we go. 


 