### PR TITLE
Add shell script for installing dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ run_dir/
 
 # Archived catalog-generation logic (kept locally, not checked in)
 scripts/_catalog_gen.py
+scripts/__pycache__/
 
 # Include images of  waveforms in Brave New World bug readme
 !tests/fpga-debugging/axis-async-fifo-c4/*.png

--- a/README.md
+++ b/README.md
@@ -18,13 +18,17 @@ These tools are all implemented in Rust, with some auxiliary benchmarking script
 
 ## Installation + Build Instructions
 
-**General dependencies**:
-Note: the installation instructions below assume a macOS environment.
+**Installation script:**
+Run `./install.sh` to install all dependencies required for macOS / Linux.
+If you want, you can also manually install dependencies, as described below.
+
+**Manually installing dependencies**:
+Note: the instructions below assume a macOS environment.
 - Ensure you have Homebrew and `uv` installed
   - If not, follow these instructions to install [Homebrew](https://brew.sh) and [uv](https://docs.astral.sh/uv/getting-started/installation/)
-- Run `brew install hyperfine` to install [Hyperfine](https://github.com/sharkdp/hyperfine), a command-line benchmarking tool 
+- (Optional) Run `brew install hyperfine` to install [Hyperfine](https://github.com/sharkdp/hyperfine), a command-line benchmarking tool 
 - Run `brew install just` to install [Just](https://github.com/casey/just), a command runner
-- Run `cargo install runt` to install [Runt](https://github.com/rachitnigam/runt), a command-line tool we use for snapshot tests, which compare the output of our tools to expected outputs stored in dedicated files 
+- Run `cargo install --git https://github.com/Nikil-Shyamsunder/runt.git` to install our fork of [Runt](https://github.com/rachitnigam/runt), a command-line tool we use for snapshot tests. Runt compares the output of our tools to expected outputs stored in dedicated files. 
 
 **Dependencies for benchmarking the monitor**:
 - Run `uv sync` to install the Python dependencies specified in `pyproject.toml` 

--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ else
     echo "Cargo already installed: $(cargo --version)"
 fi
 
-# Check that Rust version matches current version requirement is cargo.toml (1.88)
+# Check that Rust version matches current version requirement in cargo.toml (1.88)
 REQUIRED_RUST="1.88"
 CURRENT_RUST=$(rustc --version | awk '{print $2}')
 if [[ "$(printf '%s\n' "$REQUIRED_RUST" "$CURRENT_RUST" | sort -V | head -1)" != "$REQUIRED_RUST" ]]; then
@@ -86,7 +86,7 @@ fi
 
 # Install Nikil's fork of Runt
 if ! command -v runt &>/dev/null; then
-    echo "Installing our fork runt..."
+    echo "Installing our fork of runt..."
     cargo install --git https://github.com/Nikil-Shyamsunder/runt.git
 else
     echo "runt already installed: $(runt --version 2>&1 | head -1)"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+# Set exit code to non-zero if any command / any command in a pipeline fails 
+set -euo pipefail
+
+OS="$(uname -s)"
+
+# Install package manager 
+# Homebrew if MacOS, or apt-get if on Linux (e.g. Gorgonzola/Havarti)
+if [[ "$OS" == "Darwin" ]]; then
+    if ! command -v brew &>/dev/null; then
+        echo "Installing Homebrew..."
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+        if [[ -f /opt/homebrew/bin/brew ]]; then
+            eval "$(/opt/homebrew/bin/brew shellenv)"
+        fi
+    else
+        echo "Homebrew already installed: $(brew --version | head -1)"
+    fi
+elif [[ "$OS" == "Linux" ]]; then
+    if ! command -v apt-get &>/dev/null; then
+        echo "ERROR: apt-get not found" >&2
+        exit 1
+    fi
+    echo "Updating apt package lists..."
+    sudo apt-get update -q
+else
+    echo "ERROR: Unsupported OS $OS" >&2
+    exit 1
+fi
+
+# Install Rust via Rustup
+if ! command -v cargo &>/dev/null; then
+    echo "Installing Rust via rustup..."
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    # shellcheck source=/dev/null
+    source "$HOME/.cargo/env"
+else
+    echo "Cargo already installed: $(cargo --version)"
+fi
+
+# Check that Rust version matches current version requirement is cargo.toml (1.88)
+REQUIRED_RUST="1.88"
+CURRENT_RUST=$(rustc --version | awk '{print $2}')
+if [[ "$(printf '%s\n' "$REQUIRED_RUST" "$CURRENT_RUST" | sort -V | head -1)" != "$REQUIRED_RUST" ]]; then
+    echo "Rust $CURRENT_RUST is older than required version $REQUIRED_RUST, updating..."
+    rustup update stable
+fi
+
+# Install uv (for Python dependencies / virtual environments)
+if ! command -v uv &>/dev/null; then
+    echo "Installing uv..."
+    if [[ "$OS" == "Darwin" ]]; then
+        brew install uv
+    else
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        export PATH="$HOME/.local/bin:$PATH"
+    fi
+else
+    echo "uv already installed: $(uv --version)"
+fi
+
+# Install just (for running Justfiles)
+if ! command -v just &>/dev/null; then
+    echo "Installing just..."
+    if [[ "$OS" == "Darwin" ]]; then
+        brew install just
+    else
+        cargo install just
+    fi
+else
+    echo "just already installed: $(just --version)"
+fi
+
+# Install Yosys (for interpreter)
+if ! command -v yosys &>/dev/null; then
+    echo "Installing yosys..."
+    if [[ "$OS" == "Darwin" ]]; then
+        brew install yosys
+    else
+        sudo apt-get install -y yosys
+    fi
+else
+    echo "yosys already installed: $(yosys --version 2>&1 | head -1)"
+fi
+
+# Install Nikil's fork of Runt
+if ! command -v runt &>/dev/null; then
+    echo "Installing our fork runt..."
+    cargo install --git https://github.com/Nikil-Shyamsunder/runt.git
+else
+    echo "runt already installed: $(runt --version 2>&1 | head -1)"
+fi
+
+echo "Syncing Python dependencies..."
+uv sync
+
+echo -e "\nAll dependencies installed. Run 'just test' to check tests pass."


### PR DESCRIPTION
I recently set up this repo on a new machine and went through the process to manually install dependencies for local development. 

To automate / document this process, I decided to create a script `install.sh`, in case we also need to install this repo again on a server (Gorgonzola / Havarti) in the future.

The script installs the following (via Homebrew on MacOS or apt-get on Linux):
- `uv` (for Python dependencies)
- `just` (to use Justfiles)
- Install's Nikil's fork of Runt via `cargo install --git https://github.com/Nikil-Shyamsunder/runt.git` (as described in #252)
- Installs Yosys 
    + Note: this does `brew install yosys`, so it may end up installing a different version from Yosys from what is done in CI (CI runs the entire `setup-oss-cad-suite`, which takes much longer) -- hopefully doing `brew install yosys` is sufficient for this script
- Runs `uv sync` to set up Python virtual env

I checked this script using the [`shellcheck`](https://github.com/koalaman/shellcheck) tool and ran it locally on my machine to check the script works.
