### PR TITLE
serialize: runtrip through parser

### DIFF
--- a/protocols/src/frontend/ast.rs
+++ b/protocols/src/frontend/ast.rs
@@ -16,14 +16,14 @@ use crate::frontend::serialize::{build_statements, serialize_expr};
 use crate::frontend::symbol::{Arg, Dir, ScopeId, StructId, SymbolId, SymbolTable, Type};
 
 /// Frontend representation of parsed protocol files.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct Ast {
     pub st: SymbolTable,
     pub protos: Vec<Protocol>,
     pub remaps: Vec<RemapModule>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct ProtocolContext {
     /// The name of the `Protocol`
     pub name: String,
@@ -49,6 +49,19 @@ pub struct ProtocolContext {
 
     /// The scope in the [[SymbolTable]] associated with this protocol.
     pub scope: ScopeId,
+}
+
+#[cfg(test)]
+fn assert_proto_ctx_eq(a: &ProtocolContext, b: &ProtocolContext) {
+    assert_eq!(a.name, b.name);
+    assert_eq!(a.args, b.args);
+    assert_eq!(a.type_param, b.type_param);
+    assert_eq!(a.is_idle, b.is_idle);
+    assert_eq!(a.exprs, b.exprs);
+    assert_eq!(a.dont_care_id, b.dont_care_id);
+    assert_eq!(a.true_expr_id, b.true_expr_id);
+    assert_eq!(a.scope, b.scope);
+    // we intentionally do not compare the expression locations
 }
 
 impl ProtocolContext {
@@ -122,13 +135,22 @@ pub enum Clock {
 }
 
 /// Represents an unresolved `module`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct RemapModule {
     pub ctx: ProtocolContext,
     pub name: String,
     pub clock: Clock,
     pub implements: Vec<StructId>,
     pub mappings: Vec<Mapping>,
+}
+
+#[cfg(test)]
+pub(crate) fn assert_remap_eq(a: &RemapModule, b: &RemapModule) {
+    assert_proto_ctx_eq(&a.ctx, &b.ctx);
+    assert_eq!(a.name, b.name);
+    assert_eq!(a.clock, b.clock);
+    assert_eq!(a.implements, b.implements);
+    assert_eq!(a.mappings, b.mappings);
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -140,7 +162,7 @@ pub struct Mapping {
     pub cond: ExprId,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct Protocol {
     pub ctx: ProtocolContext,
 
@@ -150,6 +172,14 @@ pub struct Protocol {
     /// Maps `StmtId`s to their corresponding `Stmt`s
     stmts: PrimaryMap<StmtId, Stmt>,
     stmt_loc: SecondaryMap<StmtId, (usize, usize, usize)>,
+}
+
+#[cfg(test)]
+pub(crate) fn assert_proto_eq(a: &Protocol, b: &Protocol) {
+    assert_eq!(a.body, b.body);
+    assert_eq!(a.stmts, b.stmts);
+    // we do not compare the statement locations
+    assert_proto_ctx_eq(&a.ctx, &b.ctx);
 }
 
 impl Protocol {

--- a/protocols/src/frontend/parser.rs
+++ b/protocols/src/frontend/parser.rs
@@ -936,8 +936,10 @@ pub(crate) fn parse_files(
     let mut remaps = vec![];
     for filename in filenames {
         let display_name = filename.as_ref().to_str().unwrap();
+        let input =
+            std::fs::read_to_string(filename).map_err(|e| format!("failed to load: {}", e))?;
         parse_file_internal(
-            filename,
+            &input,
             display_name,
             &mut st,
             &mut protos,
@@ -957,8 +959,9 @@ pub(crate) fn parse_file_with_name(
     let mut st = SymbolTable::default();
     let mut protos = vec![];
     let mut remaps = vec![];
+    let input = std::fs::read_to_string(filename).map_err(|e| format!("failed to load: {}", e))?;
     parse_file_internal(
-        filename,
+        &input,
         display_name.as_ref().to_str().unwrap(),
         &mut st,
         &mut protos,
@@ -968,16 +971,31 @@ pub(crate) fn parse_file_with_name(
     Ok(Ast { st, protos, remaps })
 }
 
+#[cfg(test)]
+pub(crate) fn parse_string(content: &str, handler: &mut DiagnosticHandler) -> Result<Ast, String> {
+    let mut st = SymbolTable::default();
+    let mut protos = vec![];
+    let mut remaps = vec![];
+    parse_file_internal(
+        content,
+        "<string>",
+        &mut st,
+        &mut protos,
+        &mut remaps,
+        handler,
+    )?;
+    Ok(Ast { st, protos, remaps })
+}
+
 fn parse_file_internal(
-    filename: impl AsRef<std::path::Path>,
+    input: &str,
     display_name: &str,
     st: &mut SymbolTable,
     protos: &mut Vec<Protocol>,
     remaps: &mut Vec<RemapModule>,
     diag: &mut DiagnosticHandler,
 ) -> Result<(), String> {
-    let input = std::fs::read_to_string(filename).map_err(|e| format!("failed to load: {}", e))?;
-    let fileid = diag.add_file(display_name.into(), input.clone());
+    let fileid = diag.add_file(display_name.into(), input.to_string());
 
     let res = ProtocolParser::parse(Rule::file, &input);
     match res {

--- a/protocols/src/frontend/parser.rs
+++ b/protocols/src/frontend/parser.rs
@@ -997,7 +997,7 @@ fn parse_file_internal(
 ) -> Result<(), String> {
     let fileid = diag.add_file(display_name.into(), input.to_string());
 
-    let res = ProtocolParser::parse(Rule::file, &input);
+    let res = ProtocolParser::parse(Rule::file, input);
     match res {
         Ok(_parsed) => (),
         Err(err) => {
@@ -1011,7 +1011,7 @@ fn parse_file_internal(
         }
     }
 
-    let pairs = ProtocolParser::parse(Rule::file, &input).unwrap();
+    let pairs = ProtocolParser::parse(Rule::file, input).unwrap();
     let inner = pairs.clone().next().unwrap().into_inner();
 
     for pair in inner {

--- a/protocols/src/frontend/serialize.rs
+++ b/protocols/src/frontend/serialize.rs
@@ -150,7 +150,11 @@ where
     E: Index<ExprId, Output = Expr>,
 {
     match &exprs[*expr_id] {
-        Expr::Const(val) => val.to_u64().unwrap().to_string(),
+        Expr::Const(val) => {
+            // note: do not use serialize_bitvec since that does not actually result in
+            //       a parsable string!
+            format!("{}'d{}", val.width(), val.to_dec_str())
+        }
         Expr::Sym(symid) => st[symid].full_name(st),
         Expr::DontCare => "X".to_string(),
         Expr::IsLastIteration => "is_last()".to_string(),
@@ -360,7 +364,7 @@ pub fn serialize(out: &mut impl Write, ast: &Ast) -> std::io::Result<()> {
     }
 
     for proto in &ast.protos {
-        write!(out, "fn {}", proto.name)?;
+        write!(out, "prot {}", proto.name)?;
 
         if let Some(type_param) = proto.type_param {
             write!(
@@ -411,7 +415,7 @@ pub mod tests {
 
     use super::*;
     use crate::frontend::diagnostic::DiagnosticHandler;
-    use crate::frontend::parser::parse_file_with_name;
+    use crate::frontend::parser::{parse_file_with_name, parse_string};
     use baa::BitVecValue;
     use clap::ColorChoice;
     use insta::Settings;
@@ -428,13 +432,45 @@ pub mod tests {
     fn test_helper(filename: &str, snap_name: &str) {
         let mut handler = DiagnosticHandler::new(ColorChoice::Never, false, false, false);
         let result = parse_file_with_name(filename, display_filename(filename), &mut handler);
+        let maybe_ast = result.ok();
 
-        let content = match result {
-            Ok(ast) => serialize_to_string(&ast).unwrap(),
-            Err(_) => strip_str(handler.error_string()),
+        let content = match &maybe_ast {
+            Some(ast) => serialize_to_string(ast).unwrap(),
+            None => strip_str(handler.error_string()),
         };
         println!("{}", content);
-        snap(snap_name, content);
+        snap(snap_name, content.clone());
+
+        // round trip
+        if let Some(ast) = maybe_ast {
+            let ast2 = parse_string(&content, &mut handler).expect("failed to parse serialized");
+            assert_ast_eq(&ast, &ast2);
+        }
+    }
+
+    fn assert_ast_eq(a: &Ast, b: &Ast) {
+        assert_eq!(a.st, b.st);
+        // for the protos and remaps, we need to make sure we do not include the expression locations
+        assert_eq!(
+            a.protos.len(),
+            b.protos.len(),
+            "{:?}\n{:?}",
+            a.protos,
+            b.protos
+        );
+        for (pa, pb) in a.protos.iter().zip(b.protos.iter()) {
+            assert_proto_eq(pa, pb);
+        }
+        assert_eq!(
+            a.remaps.len(),
+            b.remaps.len(),
+            "{:?}\n{:?}",
+            a.remaps,
+            b.remaps
+        );
+        for (ra, rb) in a.remaps.iter().zip(b.remaps.iter()) {
+            assert_remap_eq(ra, rb);
+        }
     }
 
     fn display_filename(filename: &str) -> &str {

--- a/protocols/src/tests/snapshots/protocols__frontend__serialize__tests__add_d1.snap
+++ b/protocols/src/tests/snapshots/protocols__frontend__serialize__tests__add_d1.snap
@@ -8,7 +8,7 @@ struct Adder {
   out s: u32,
 }
 
-fn add<DUT: Adder>(a: u32, b: u32, s: u32) {
+prot add<DUT: Adder>(a: u32, b: u32, s: u32) {
   DUT.a := a;
   DUT.b := b;
   step();
@@ -19,7 +19,7 @@ fn add<DUT: Adder>(a: u32, b: u32, s: u32) {
   step();
 }
 
-fn add_fork_early<DUT: Adder>(a: u32, b: u32, s: u32) {
+prot add_fork_early<DUT: Adder>(a: u32, b: u32, s: u32) {
   DUT.a := a;
   DUT.b := b;
   step();
@@ -30,7 +30,7 @@ fn add_fork_early<DUT: Adder>(a: u32, b: u32, s: u32) {
   step();
 }
 
-fn add_incorrect<DUT: Adder>(a: u32, b: u32, s: u32) {
+prot add_incorrect<DUT: Adder>(a: u32, b: u32, s: u32) {
   DUT.a := a;
   DUT.b := b;
   step();
@@ -41,7 +41,7 @@ fn add_incorrect<DUT: Adder>(a: u32, b: u32, s: u32) {
   step();
 }
 
-fn add_incorrect_implicit<DUT: Adder>(a: u32, b: u32, s: u32) {
+prot add_incorrect_implicit<DUT: Adder>(a: u32, b: u32, s: u32) {
   DUT.a := a;
   DUT.b := b;
   step();
@@ -50,7 +50,7 @@ fn add_incorrect_implicit<DUT: Adder>(a: u32, b: u32, s: u32) {
   step();
 }
 
-fn wait_and_add<DUT: Adder>(a: u32, b: u32, s: u32) {
+prot wait_and_add<DUT: Adder>(a: u32, b: u32, s: u32) {
   step();
   fork();
   step();
@@ -61,10 +61,10 @@ fn wait_and_add<DUT: Adder>(a: u32, b: u32, s: u32) {
   step();
 }
 
-fn assign_after_observation<DUT: Adder>(a: u32, b: u32, s: u32) {
+prot assign_after_observation<DUT: Adder>(a: u32, b: u32, s: u32) {
   DUT.a := a;
-  if DUT.a == 2 {
-    DUT.a := 0;
+  if DUT.a == 32'd2 {
+    DUT.a := 32'd0;
   } else {
   }
   DUT.b := b;
@@ -76,13 +76,13 @@ fn assign_after_observation<DUT: Adder>(a: u32, b: u32, s: u32) {
   step();
 }
 
-fn if_else<DUT: Adder>(a1: u32, a2: u32) {
-  if 1 {
+prot if_else<DUT: Adder>(a1: u32, a2: u32) {
+  if 1'd1 {
     DUT.a := a1;
   } else {
     DUT.a := a2;
   }
-  DUT.b := 0;
+  DUT.b := 32'd0;
   step();
   DUT.a := X;
   DUT.b := X;

--- a/protocols/src/tests/snapshots/protocols__frontend__serialize__tests__calyx_go_done_struct.snap
+++ b/protocols/src/tests/snapshots/protocols__frontend__serialize__tests__calyx_go_done_struct.snap
@@ -9,13 +9,13 @@ struct Calyx {
   out oo: u32,
 }
 
-fn calyx_go_done<dut: Calyx>(ii: u32, oo: u32) {
+prot calyx_go_done<dut: Calyx>(ii: u32, oo: u32) {
   dut.ii := ii;
-  dut.go := 1;
-  while !(dut.done == 1) {
+  dut.go := 32'd1;
+  while !(dut.done == 1'd1) {
     step();
   }
-  dut.go := 0;
+  dut.go := 32'd0;
   dut.ii := X;
   assert_eq(dut.oo, oo);
   step();

--- a/protocols/src/tests/snapshots/protocols__frontend__serialize__tests__cond.snap
+++ b/protocols/src/tests/snapshots/protocols__frontend__serialize__tests__cond.snap
@@ -9,7 +9,7 @@ struct Multiplier {
   out s: u32,
 }
 
-fn mul<dut: Multiplier>(a: u32, b: u32, s: u32) {
+prot mul<dut: Multiplier>(a: u32, b: u32, s: u32) {
   dut.a := a;
   dut.b := b;
   step();
@@ -18,12 +18,12 @@ fn mul<dut: Multiplier>(a: u32, b: u32, s: u32) {
   dut.a := X;
   dut.b := X;
   step();
-  if 8 == 0 {
+  if 4'd8 == 4'd0 {
     step();
   } else {
     fork();
   }
-  assert_eq(dut.c, 1);
+  assert_eq(dut.c, 1'd1);
   assert_eq(s, dut.s);
   step();
 }

--- a/protocols/src/tests/snapshots/protocols__frontend__serialize__tests__if_without_else.snap
+++ b/protocols/src/tests/snapshots/protocols__frontend__serialize__tests__if_without_else.snap
@@ -7,8 +7,8 @@ struct DualIdentity {
   in b: u64,
 }
 
-fn if_without_else<dut: DualIdentity>(a: u64, b: u64) {
-  if dut.b == 1 {
+prot if_without_else<dut: DualIdentity>(a: u64, b: u64) {
+  if dut.b == 64'd1 {
     dut.a := a;
   } else {
   }

--- a/protocols/src/tests/snapshots/protocols__frontend__serialize__tests__loop_with_assigns.snap
+++ b/protocols/src/tests/snapshots/protocols__frontend__serialize__tests__loop_with_assigns.snap
@@ -8,7 +8,7 @@ struct Adder {
   out s: u32,
 }
 
-fn loop_add<DUT: Adder>(a: u32, b: u32, num_iters: uint, s: u32) {
+prot loop_add<DUT: Adder>(a: u32, b: u32, num_iters: uint, s: u32) {
   repeat num_iters iterations {
     DUT.a := a;
     DUT.b := b;

--- a/protocols/src/tests/snapshots/protocols__frontend__serialize__tests__mul.snap
+++ b/protocols/src/tests/snapshots/protocols__frontend__serialize__tests__mul.snap
@@ -8,7 +8,7 @@ struct Multiplier {
   out s: u32,
 }
 
-fn mul<dut: Multiplier>(a: u32, b: u32, s: u32) {
+prot mul<dut: Multiplier>(a: u32, b: u32, s: u32) {
   dut.a := a;
   dut.b := b;
   step();

--- a/protocols/src/tests/snapshots/protocols__frontend__serialize__tests__mul_ignore.snap
+++ b/protocols/src/tests/snapshots/protocols__frontend__serialize__tests__mul_ignore.snap
@@ -8,7 +8,7 @@ struct Multiplier {
   out s: u32,
 }
 
-fn mul<dut: Multiplier>(a: u32, b: u32, s: u32) {
+prot mul<dut: Multiplier>(a: u32, b: u32, s: u32) {
   dut.a := a;
   dut.b := b;
   step();
@@ -21,7 +21,7 @@ fn mul<dut: Multiplier>(a: u32, b: u32, s: u32) {
   step();
 }
 
-fn ignore<dut: Multiplier>(a: u32, b: u32, s: u32) {
+prot ignore<dut: Multiplier>(a: u32, b: u32, s: u32) {
   dut.a := a;
   dut.b := b;
   step();

--- a/protocols/src/tests/snapshots/protocols__frontend__serialize__tests__nested_bounded_loop.snap
+++ b/protocols/src/tests/snapshots/protocols__frontend__serialize__tests__nested_bounded_loop.snap
@@ -8,7 +8,7 @@ struct Adder {
   out s: u32,
 }
 
-fn nested_busy_wait<DUT: Adder>(a: u32, b: u32, outer_iters: uint, inner_iters: uint, s: u32) {
+prot nested_busy_wait<DUT: Adder>(a: u32, b: u32, outer_iters: uint, inner_iters: uint, s: u32) {
   DUT.a := a;
   DUT.b := b;
   repeat outer_iters iterations {

--- a/protocols/src/tests/snapshots/protocols__frontend__serialize__tests__simple_bounded_loop.snap
+++ b/protocols/src/tests/snapshots/protocols__frontend__serialize__tests__simple_bounded_loop.snap
@@ -7,7 +7,7 @@ struct Counter {
   out s: u64,
 }
 
-fn simple_bounded_loop<dut: Counter>(a: u64, num_iterations: uint, s: u64) {
+prot simple_bounded_loop<dut: Counter>(a: u64, num_iterations: uint, s: u64) {
   dut.a := a;
   repeat num_iterations iterations {
     step();

--- a/protocols/src/tests/snapshots/protocols__frontend__serialize__tests__simple_if.snap
+++ b/protocols/src/tests/snapshots/protocols__frontend__serialize__tests__simple_if.snap
@@ -7,12 +7,12 @@ struct Counter {
   out s: u64,
 }
 
-fn simple_if<dut: Counter>(a: u64, s: u64) {
+prot simple_if<dut: Counter>(a: u64, s: u64) {
   dut.a := a;
   step();
   step();
-  if dut.s == 3 {
-    assert_eq(dut.s, 0);
+  if dut.s == 64'd3 {
+    assert_eq(dut.s, 64'd0);
   } else {
     step();
     step();
@@ -20,9 +20,9 @@ fn simple_if<dut: Counter>(a: u64, s: u64) {
     step();
     step();
   }
-  if dut.s == 7 {
+  if dut.s == 64'd7 {
     assert_eq(dut.s, s);
   } else {
-    assert_eq(dut.s, 0);
+    assert_eq(dut.s, 64'd0);
   }
 }

--- a/protocols/src/tests/snapshots/protocols__frontend__serialize__tests__simple_while.snap
+++ b/protocols/src/tests/snapshots/protocols__frontend__serialize__tests__simple_while.snap
@@ -7,9 +7,9 @@ struct Counter {
   out s: u64,
 }
 
-fn simple_while<dut: Counter>(a: u64, b: u64, s: u64) {
+prot simple_while<dut: Counter>(a: u64, b: u64, s: u64) {
   dut.a := a;
-  while !(dut.s == 1) {
+  while !(dut.s == 64'd1) {
     step();
   }
   step();


### PR DESCRIPTION
The tests for the `serialize` function now roundtrip the result through the parser and compare the resulting AST.