### PR TITLE
Static Fork Analysis

### DIFF
--- a/protocols/src/ir/determinize.rs
+++ b/protocols/src/ir/determinize.rs
@@ -36,7 +36,7 @@ fn get_or_create_state(
 pub enum SatResult {
     DefinitelyUnsat,
     MaybeSat,
-    DefinitelySat,
+    AlwaysSat,
 }
 
 // TODO: Strengthen this with a real SAT/SMT query to prune more aggressively.
@@ -49,7 +49,7 @@ pub fn check_sat(protocol: &mut ProtoGraph, guard: ExprRef) -> SatResult {
     if simplified == protocol.false_id() {
         SatResult::DefinitelyUnsat
     } else if simplified == protocol.true_id() {
-        SatResult::DefinitelySat
+        SatResult::AlwaysSat
     } else {
         SatResult::MaybeSat
     }
@@ -115,7 +115,7 @@ pub fn determinized(protocol: ProtoGraph, symbols: &SymbolTable) -> ProtoGraph {
 
             let guard = match check_sat(&mut protocol, guard) {
                 SatResult::DefinitelyUnsat => continue,
-                SatResult::DefinitelySat => protocol.true_id(),
+                SatResult::AlwaysSat => protocol.true_id(),
                 SatResult::MaybeSat => guard,
             };
 

--- a/protocols/src/ir/fork_reach.rs
+++ b/protocols/src/ir/fork_reach.rs
@@ -1,0 +1,304 @@
+use crate::ir::determinize::{SatResult, check_sat};
+use crate::ir::proto_graph::{NodeId, Op, ProtoGraph};
+use crate::ir::reaching_defs::{predecessors, restrict_branch_to_edge, simplify_guard};
+use itertools::Itertools;
+use patronus::expr::ExprRef;
+use rustc_hash::FxHashMap;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ForkReachability {
+    Unreachable,
+    DefinitelyNotForked,
+    MaybeForked,
+    DefinitelyForked,
+}
+
+#[derive(Debug, Default)]
+pub struct ForkReach {
+    pub in_reach: FxHashMap<NodeId, ForkReachability>,
+    pub out_reach: FxHashMap<NodeId, ForkReachability>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ForkFact {
+    // if `no_fork_guard` is true, there is a path where no fork was triggered
+    // if `fork_guard` is true, there is a path where a fork was triggered
+    no_fork_guard: ExprRef,
+    fork_guard: ExprRef,
+}
+
+impl ForkFact {
+    fn bottom(pg: &ProtoGraph) -> Self {
+        Self {
+            no_fork_guard: pg.false_id(),
+            fork_guard: pg.false_id(),
+        }
+    }
+
+    fn initial(pg: &ProtoGraph) -> Self {
+        Self {
+            // initially, we know there is a path where no fork was triggered (the trivial path)
+            no_fork_guard: pg.true_id(),
+            fork_guard: pg.false_id(),
+        }
+    }
+
+    fn merge(pg: &mut ProtoGraph, lhs: Self, rhs: Self) -> Self {
+        // merge all the paths where no fork was taken with OR, likewise for the fork taken paths
+        let no_fork_guard = pg.or_guard(lhs.no_fork_guard, rhs.no_fork_guard);
+        let fork_guard = pg.or_guard(lhs.fork_guard, rhs.fork_guard);
+        Self {
+            no_fork_guard: simplify_guard(pg, no_fork_guard),
+            fork_guard: simplify_guard(pg, fork_guard),
+        }
+    }
+
+    fn transfer(self, pg: &mut ProtoGraph, local_fork_guard: ExprRef) -> Self {
+        // no fork is taken *out of* this node if into this path, the no_fork_guard is true AND the fork in this node was not triggered
+        let not_local_fork = pg.not_guard(local_fork_guard);
+        let no_fork_guard = pg.and_guard(self.no_fork_guard, not_local_fork);
+
+        // a fork was taken if there are paths that already forked OR this fork triggered
+        let fork_guard = pg.or_guard(self.fork_guard, local_fork_guard);
+        Self {
+            no_fork_guard: simplify_guard(pg, no_fork_guard),
+            fork_guard: simplify_guard(pg, fork_guard),
+        }
+    }
+
+    /// converts information about the guards into a statement about whether a fork might've occurred so far
+    fn reachability(self, pg: &mut ProtoGraph) -> ForkReachability {
+        let no_fork_guard = simplify_guard(pg, self.no_fork_guard);
+        let fork_guard = simplify_guard(pg, self.fork_guard);
+
+        match (check_sat(pg, no_fork_guard), check_sat(pg, fork_guard)) {
+            // if both a fork happening and not happening is unsat, this is the bottom which would only happen for totally unreachable nodes?
+            (SatResult::DefinitelyUnsat, SatResult::DefinitelyUnsat) => {
+                ForkReachability::Unreachable
+            }
+            // if the fork guard is unsat, then we definitely didn't fork
+            (_, SatResult::DefinitelyUnsat) => ForkReachability::DefinitelyNotForked,
+
+            // if the not fork guard is unsat and the fork guard is true, we definitely forked
+            (SatResult::DefinitelyUnsat, SatResult::AlwaysSat) => {
+                ForkReachability::DefinitelyForked
+            }
+
+            _ => ForkReachability::MaybeForked,
+        }
+    }
+}
+
+pub fn reaching_forks_from(pg: &mut ProtoGraph, start: NodeId) -> ForkReach {
+    // let reachable = reachable_node_ids(pg, start);
+    let preds = predecessors(pg);
+    let mut in_facts: FxHashMap<NodeId, ForkFact> = FxHashMap::default();
+    let mut out: FxHashMap<NodeId, ForkFact> = FxHashMap::default();
+    let node_ids: Vec<NodeId> = pg.nodes().map(|(nid, _)| nid).collect();
+    let mut worklist = node_ids.clone();
+
+    while let Some(id) = worklist.pop() {
+        // initialize the in_fact
+        let mut in_fact = if id == start {
+            ForkFact::initial(pg)
+        } else {
+            ForkFact::bottom(pg)
+        };
+
+        // compute the in fact by merging across all predecessors, simplifying guards given
+        // we know the edges taken
+        for (pred_id, transition_guard) in preds.get(&id).into_iter().flatten() {
+            let pred_fact = out.get(pred_id).copied().unwrap_or(ForkFact::bottom(pg));
+
+            let edge_no_fork_guard =
+                restrict_branch_to_edge(pg, pred_fact.no_fork_guard, *transition_guard)
+                    .unwrap_or_else(|| pg.false_id());
+            let edge_fork_guard =
+                restrict_branch_to_edge(pg, pred_fact.fork_guard, *transition_guard)
+                    .unwrap_or_else(|| pg.false_id());
+            if edge_no_fork_guard == pg.false_id() && edge_fork_guard == pg.false_id() {
+                continue;
+            }
+
+            in_fact = ForkFact::merge(
+                pg,
+                in_fact,
+                ForkFact {
+                    no_fork_guard: edge_no_fork_guard,
+                    fork_guard: edge_fork_guard,
+                },
+            );
+        }
+
+        // compute the current nodes fork guard. `guards` should always be a singleton
+        // by the invariants of the compiler, but we can handle multiple by OR-ing them
+        let guards = pg[id]
+            .actions
+            .iter()
+            .filter_map(|action| matches!(pg[action.op], Op::Fork).then_some(action.guard))
+            .collect_vec();
+
+        let guard = guards.into_iter().fold(pg.false_id(), |guard, fork_guard| {
+            pg.or_guard(guard, fork_guard)
+        });
+        let fork_guard = simplify_guard(pg, guard);
+
+        // compute the transfer, update the facts map, and re-enqueue successors
+        // if things have changed
+        let new_out = in_fact.transfer(pg, fork_guard);
+        if in_facts.get(&id) != Some(&in_fact) || out.get(&id) != Some(&new_out) {
+            in_facts.insert(id, in_fact);
+            out.insert(id, new_out);
+            worklist.extend(pg[id].transitions.iter().map(|t| t.target).unique());
+        }
+    }
+
+    // convert the facts into our reachability enum
+    let mut in_reach = FxHashMap::default();
+    let mut out_reach = FxHashMap::default();
+
+    for id in node_ids {
+        let in_fact = in_facts.get(&id).copied().unwrap_or(ForkFact::bottom(pg));
+        let out_fact = out.get(&id).copied().unwrap_or(ForkFact::bottom(pg));
+        in_reach.insert(id, in_fact.reachability(pg));
+        out_reach.insert(id, out_fact.reachability(pg));
+    }
+
+    ForkReach {
+        in_reach,
+        out_reach,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frontend::ast::ProtocolContext;
+    use crate::frontend::symbol::ROOT_SCOPE;
+    use crate::ir::proto_graph::{Action, Node, Transition};
+
+    fn test_graph() -> ProtoGraph {
+        ProtoGraph::new(ProtocolContext::new("test".into(), ROOT_SCOPE))
+    }
+
+    fn push_fork(pg: &mut ProtoGraph, node_id: NodeId) {
+        let fork = pg.o(Op::Fork);
+        pg.push_action(node_id, Action::new(pg.true_id(), fork));
+    }
+
+    fn push_guarded_fork(pg: &mut ProtoGraph, node_id: NodeId, guard: ExprRef) {
+        let fork = pg.o(Op::Fork);
+        pg.push_action(node_id, Action::new(guard, fork));
+    }
+
+    fn fork_reachability_at(pg: &mut ProtoGraph, id: NodeId) -> ForkReachability {
+        reaching_forks_from(pg, pg.entry)
+            .out_reach
+            .get(&id)
+            .copied()
+            .unwrap_or(ForkReachability::Unreachable)
+    }
+
+    // straight line code with unconditional fork gives "DefinitelyForked"
+    #[test]
+    fn classifies_definitely_forked_after_fork() {
+        let mut pg = test_graph();
+        let fork = pg.n(Node::empty());
+        let exit = pg.n(Node::empty());
+
+        push_fork(&mut pg, fork);
+        let true_id = pg.true_id();
+        pg.push_transition(pg.entry, Transition::new(true_id, fork, false));
+        pg.push_transition(fork, Transition::new(true_id, exit, false));
+
+        assert_eq!(
+            fork_reachability_at(&mut pg, exit),
+            ForkReachability::DefinitelyForked
+        );
+    }
+
+    #[test]
+    // straight line code with MaybeSat fork gives "DefinitelyForked"
+    fn classifies_guarded_fork_as_maybe_forked() {
+        let mut pg = test_graph();
+        let fork = pg.n(Node::empty());
+        let exit = pg.n(Node::empty());
+        let p = pg.expr_ctx.bv_symbol("p", 1);
+
+        push_guarded_fork(&mut pg, fork, p);
+        let true_id = pg.true_id();
+        pg.push_transition(pg.entry, Transition::new(true_id, fork, false));
+        pg.push_transition(fork, Transition::new(true_id, exit, false));
+
+        assert_eq!(
+            fork_reachability_at(&mut pg, exit),
+            ForkReachability::MaybeForked
+        );
+    }
+
+    // straight line code without a fork gives "DefinitelyNotForked"
+    #[test]
+    fn classifies_definitely_not_forked_without_fork() {
+        let mut pg = test_graph();
+        let exit = pg.n(Node::empty());
+
+        let true_id = pg.true_id();
+        pg.push_transition(pg.entry, Transition::new(true_id, exit, false));
+
+        assert_eq!(
+            fork_reachability_at(&mut pg, exit),
+            ForkReachability::DefinitelyNotForked
+        );
+    }
+
+    #[test]
+    fn classifies_maybe_forked_at_join() {
+        let mut pg = test_graph();
+        let fork = pg.n(Node::empty());
+        let no_fork = pg.n(Node::empty());
+        let join = pg.n(Node::empty());
+
+        // entry -> node with fork -> join
+        // entry -> node without fork -> join
+
+        push_fork(&mut pg, fork);
+        let true_id = pg.true_id();
+        pg.push_transition(pg.entry, Transition::new(true_id, fork, false));
+        pg.push_transition(pg.entry, Transition::new(true_id, no_fork, false));
+        pg.push_transition(fork, Transition::new(true_id, join, false));
+        pg.push_transition(no_fork, Transition::new(true_id, join, false));
+
+        assert_eq!(
+            fork_reachability_at(&mut pg, join),
+            ForkReachability::MaybeForked
+        );
+    }
+
+    #[test]
+    fn transition_guard_refines_guarded_fork() {
+        let mut pg = test_graph();
+        let fork = pg.n(Node::empty());
+        let forked_exit = pg.n(Node::empty());
+        let not_forked_exit = pg.n(Node::empty());
+        let p = pg.expr_ctx.bv_symbol("p", 1);
+        let not_p = pg.not_guard(p);
+
+        // entry -> [p] fork [p]-> forked_exit
+        // entry -> [p] fork [!p]-> not-forked_exit
+
+        push_guarded_fork(&mut pg, fork, p);
+        let true_id = pg.true_id();
+        pg.push_transition(pg.entry, Transition::new(true_id, fork, false));
+        pg.push_transition(fork, Transition::new(p, forked_exit, false));
+        pg.push_transition(fork, Transition::new(not_p, not_forked_exit, false));
+
+        assert_eq!(
+            fork_reachability_at(&mut pg, forked_exit),
+            ForkReachability::DefinitelyForked
+        );
+        assert_eq!(
+            fork_reachability_at(&mut pg, not_forked_exit),
+            ForkReachability::DefinitelyNotForked
+        );
+    }
+}

--- a/protocols/src/ir/mod.rs
+++ b/protocols/src/ir/mod.rs
@@ -1,5 +1,6 @@
 pub mod determinize;
 pub mod edge_contract;
+pub mod fork_reach;
 pub mod graph_interpreter;
 pub mod graphviz;
 pub mod lowering;

--- a/protocols/src/ir/propagate_assigns.rs
+++ b/protocols/src/ir/propagate_assigns.rs
@@ -5,10 +5,10 @@ use cranelift_entity::EntitySet;
 use rustc_hash::FxHashMap;
 
 // BFS from the entry
-fn reachable_node_ids(pg: &ProtoGraph) -> Vec<NodeId> {
+pub fn reachable_node_ids(pg: &ProtoGraph, start: NodeId) -> Vec<NodeId> {
     let mut visited: EntitySet<NodeId> = EntitySet::default();
     let mut nodes = Vec::new();
-    let mut q = vec![pg.entry];
+    let mut q = vec![start];
 
     while let Some(nid) = q.pop() {
         if !visited.insert(nid) {
@@ -41,7 +41,7 @@ fn all_ports_present(
         .filter(|sym_id| st[*sym_id].is_in_port())
         .collect();
 
-    for nid in reachable_node_ids(pg) {
+    for nid in reachable_node_ids(pg, pg.entry) {
         let Some(rd) = reaching_defs.get(&nid) else {
             return false;
         };
@@ -76,7 +76,7 @@ pub fn propagate_assignments(
         .filter(|sym_id| st[*sym_id].is_in_port())
         .collect();
 
-    let node_ids = reachable_node_ids(pg);
+    let node_ids = reachable_node_ids(pg, pg.entry);
 
     for id in node_ids {
         let Some(node_defs) = rd.get(&id) else {

--- a/protocols/src/ir/reaching_defs.rs
+++ b/protocols/src/ir/reaching_defs.rs
@@ -13,9 +13,9 @@ use rustc_hash::{FxHashMap, FxHashSet};
 // Maps ports (by their `String` name`), to the existing Assignment for that port
 pub type ReachingDefs = FxHashMap<String, Assignment>;
 
-/// Nodes only store their outgoing transitions. This function precomputes and returns
-/// the in-neighbors for each node that is reachable from the entry.
-fn predecessors(pg: &ProtoGraph) -> FxHashMap<NodeId, Vec<(NodeId, ExprRef)>> {
+/// Nodes only store their outgoing transitions. This function precomputes and
+/// returns the in-neighbors for each node.
+pub fn predecessors(pg: &ProtoGraph) -> FxHashMap<NodeId, Vec<(NodeId, ExprRef)>> {
     let mut predecessors: FxHashMap<NodeId, Vec<(NodeId, ExprRef)>> = FxHashMap::default();
 
     for (n, _) in pg.nodes() {
@@ -27,7 +27,7 @@ fn predecessors(pg: &ProtoGraph) -> FxHashMap<NodeId, Vec<(NodeId, ExprRef)>> {
     predecessors
 }
 
-fn simplify_guard(pg: &mut ProtoGraph, guard: ExprRef) -> ExprRef {
+pub fn simplify_guard(pg: &mut ProtoGraph, guard: ExprRef) -> ExprRef {
     let (expr_ctx, simplifier) = (&mut pg.expr_ctx, &mut pg.simplifier);
     simplifier.simplify(expr_ctx, guard)
 }
@@ -54,7 +54,7 @@ pub fn canonicalize_assignment(pg: &mut ProtoGraph, assignment: Assignment) -> A
 
         match check_sat(pg, effective_guard) {
             SatResult::DefinitelyUnsat => {}
-            SatResult::DefinitelySat => {
+            SatResult::AlwaysSat => {
                 merge_concrete_guard(pg, &mut concretes, pg.true_id(), rhs);
                 break;
             }
@@ -107,7 +107,7 @@ pub fn assignment_is_total(pg: &mut ProtoGraph, assignment: &Assignment) -> bool
         });
 
     match check_sat(pg, coverage) {
-        SatResult::DefinitelySat => true,
+        SatResult::AlwaysSat => true,
         SatResult::DefinitelyUnsat | SatResult::MaybeSat => false,
     }
 }
@@ -115,7 +115,7 @@ pub fn assignment_is_total(pg: &mut ProtoGraph, assignment: &Assignment) -> bool
 /// Take `branch_guard`, i.e. a guard on an assignment and simplify it to `Some(g)`
 /// under the assumption that `transition_guard` is true. If returns `None`
 /// then the branch can be removed.
-fn restrict_branch_to_edge(
+pub fn restrict_branch_to_edge(
     pg: &mut ProtoGraph,
     branch_guard: ExprRef,
     transition_guard: ExprRef,

--- a/protocols/src/ir/trace_lowering.rs
+++ b/protocols/src/ir/trace_lowering.rs
@@ -10,6 +10,7 @@ use crate::Value;
 use crate::frontend::ast::Protocol;
 use crate::frontend::symbol::SymbolTable;
 use crate::ir::edge_contract::{append_action, contract_edges, guard_assignment};
+use crate::ir::fork_reach::{ForkReachability, reaching_forks_from};
 use crate::ir::lowering::{LoweredFragmentInfo, Lowerer, TraceArgSubst};
 use crate::ir::proto_graph::{Action, NodeId, Op, ProtoGraph, Transition};
 
@@ -42,11 +43,15 @@ impl<'a> Lowerer<'a> {
         self.lower_protocol_fragment(ast, keep_done)
     }
 
-    fn next_trace_graft_points(&self, fragment: &LoweredFragmentInfo) -> Vec<(NodeId, ExprRef)> {
+    fn next_trace_graft_points(
+        &mut self,
+        fragment: &LoweredFragmentInfo,
+    ) -> Vec<(NodeId, ExprRef)> {
+        let fork_reach = reaching_forks_from(&mut self.ir, fragment.entry);
         let ir = &self.ir;
 
         // find all the forks in the IR that are within this lowered fragment (the most recent transaction we lowered).
-        let forks: Vec<(NodeId, ExprRef)> = fragment
+        let mut graft_points: Vec<(NodeId, ExprRef)> = fragment
             .nodes
             .iter()
             .flat_map(|id| {
@@ -58,13 +63,38 @@ impl<'a> Lowerer<'a> {
             })
             .collect();
 
-        // TODO: we should also graft onto done, but guarded by if the fork is never raised
-        // (some sort of internal state)?
-        if forks.is_empty() {
-            vec![(fragment.exit, self.ir.true_id())]
-        } else {
-            forks
+        // at every fork point, we want to have it proven that we haven't forked before
+        for (fork_node, _) in &graft_points {
+            let reachability = fork_reach.in_reach.get(fork_node).copied().unwrap();
+            assert!(
+                matches!(
+                    reachability,
+                    // nodes never get cleaned up, so there are old (pre-contraction) fork nodes that are Unreachable we need to account for
+                    ForkReachability::Unreachable | ForkReachability::DefinitelyNotForked
+                ),
+                "fork node {fork_node} can be reached after a prior fork"
+            );
         }
+
+        // if we can prove we haven't forked up to know, we'll also graft onto the exit
+        // if we can prove we have forked up to know, we won't graft onto the exit node
+        // otherwise, panic! - we're gonna have an exponential blowup
+        let exit_reachability = fork_reach
+            .in_reach
+            .get(&fragment.exit)
+            .copied()
+            .unwrap_or(ForkReachability::Unreachable);
+        match exit_reachability {
+            ForkReachability::DefinitelyNotForked => {
+                graft_points.push((fragment.exit, self.ir.true_id()));
+            }
+            ForkReachability::DefinitelyForked | ForkReachability::Unreachable => {}
+            ForkReachability::MaybeForked => {
+                panic!("done node {} may or may not have forked", fragment.exit);
+            }
+        }
+
+        graft_points
     }
 
     /// Merge a contracted entry node directly into a graft_points node using an unordered node merge.


### PR DESCRIPTION
~~Do not merge until #271~~
**The analysis:** 
- this is a very similar analysis to the assignment analysis, but different enough (and way simpler) that I ended up writing new data structures and a separate file for the analysis. Putting it in the existing assignment analysis would be more confusing probably. Luckily, it ended up being relatively simple to implement (like 150 LOC)
- Every node has an in_fact and an out_fact, which are of type `ForkFact`
 - a `ForkFact` is a `no_fork_guard: ExprRef` and a `fork_guard: ExprRef`. `no_fork_guard` means "if this is true, there is some path ending at this node where no fork is triggered". `fork_guard` means "if this is true, there is some path ending at this node where a fork *is* triggered."
 -  The merge function is just OR-ing the `no_fork_guard` for all in neighbors, and same for the `fork_guard`s. The catch is that we know which edges must've been taken, so we can do a similar trick as in the assignment analysis and say "if the predecessor forks under `p` and only transitions to this node under `p`, it definitely forked: simplify to true".  We then simplify/canonicalize the expressions.
 - If there is a fork guarded by `p` in this node, the transfer function is just OR-ing with `p` on the `fork_guard` and OR-ing with `!p` on the `not_fork_guard`. 
 - Once again, I don't really have a good reason why this will converge because it'd dependent on the simplifier, but in our cases this works great
 - Then we do the traditional worklist thing

**Using the analysis:**
Once we have the in_fact and out_fact for each node at the fixpoint, we can make the following inferences for some node `n`:
- if the in_fact `fork_guard` to `n`  is `DefinitelyUnsat` (the expression simplifies to false), we definitely didn't fork before this
- if the in_fact `not_fork_guard` to `n` is `DefinitelyUnsat` and the `fork_guard` to `n` is `AlwaysSat` (the expression simplifies to true), we definitely did fork before this 
- otherwise, we `MaybeForked`

**Assertions:**
- For every node that has a fork, we assert that the `in_fact` `fork_guard` to this node is `DefinitelyNotForked`. i.e. if we hit a fork, we haven't forked prior. This is maybe too strong an assertion, but for now everything satisfies this. 
- For the done Node, we want to prove we either `DefinitelyNotForked` or `DefinitelyForked`. If we `MaybeForked` we need internal state, so we panic for now. If we `DefinitelyNotForked`, then we graft the next protocol onto the done node. If we `DefinitelyForked`, we do not. 

**Testing:**
All the tests pass without tripping those assertions. Also I wrote very targeted unit tests that test different important cases for the analysis. 


While it's not in the rust suite because it needs extra flags and some modifications, for a sanity check I also was able to test that the following protocol, run with `--skip-static-step-fork-checks` panics after the analysis because `fork node node6 can be reached after a prior fork`

```
prot add_double_fork<DUT: Adder>(a: u32, b: u32, s: u32) {
  DUT.a := a;
  DUT.b := b;
  fork();
  step();
  fork();
  DUT.a := X;
  DUT.b := X;

  assert_eq(s, DUT.s);
  step();
}
```

**Other Minor stuff:**
- Changed `DefinitelySat` to `AlwaysSat` because I think that is more descriptive. `AlwaysSat` is just if the expression tautologically simplifies to true. 
- `propogate_assigns.rs` and `reaching_defs.rs` have some small changes which are just generalizing helpers so I can use them in the fork analysis as well

 