### PR TITLE
Compile to Patronus Transition System

### DIFF
--- a/graph-interp/src/main.rs
+++ b/graph-interp/src/main.rs
@@ -1,6 +1,7 @@
-use std::panic::{AssertUnwindSafe, catch_unwind};
 use clap::Parser;
+use baa::Value as BaaValue;
 use patronus::expr::ExprRef;
+use patronus::sim::{InitKind, Interpreter, Simulator};
 use protocols::ascii_waveform::print_ascii_waveform;
 use protocols::backends::into_transition_system;
 use protocols::frontend::ast::{Ast, Protocol};
@@ -16,8 +17,10 @@ use protocols::ir::propagate_assigns::propagate_assignments;
 use protocols::ir::proto_graph::ProtoGraph;
 use protocols::ir::reaching_defs::{format_reaching_defs, reaching_definitions};
 use protocols::ir::trace_lowering::lower_trace_to_ir;
-use protocols::{PatronusSim, Value, frontend, transaction_frontend, PortId};
+use protocols::interpreter::Value as WaveValue;
+use protocols::{PatronusSim, PortId, Value, frontend, transaction_frontend};
 use rustc_hash::FxHashMap;
+use std::panic::{AssertUnwindSafe, catch_unwind};
 
 #[derive(Parser, Debug)]
 struct Cli {
@@ -117,6 +120,20 @@ fn print_trace_success(trace_index: usize) {
 fn print_trace_separator(trace_index: usize) {
     if trace_index > 0 {
         println!("\n---\n");
+    }
+}
+
+fn record_transition_waveform(
+    waveform: &mut FxHashMap<PortId, Vec<WaveValue>>,
+    sim: &Interpreter,
+    port_expr_refs: &FxHashMap<PortId, ExprRef>,
+) {
+    for (port, expr) in port_expr_refs {
+        let value = match sim.get(*expr) {
+            BaaValue::BitVec(value) => WaveValue::Concrete(value),
+            BaaValue::Array(_) => panic!("DUT ports should be bit-vectors"),
+        };
+        waveform.entry(*port).or_default().push(value);
     }
 }
 
@@ -251,8 +268,8 @@ fn run_transition_system(
         let sys = sim.sys.clone();
         let port_map = sim.port_map.clone();
         let port_expr_refs: FxHashMap<PortId, ExprRef> = FxHashMap::from_iter(
-            sim.inputs()
-                .filter_map(|input| sim.get_port_expr(input).map(|expr| (input, expr))),
+            sim.ios()
+                .filter_map(|port| sim.get_port_expr(port).map(|expr| (port, expr))),
         );
 
         let mut joint = lower_trace_to_ir(trace, &protos_by_name, st, sim.ctx.clone());
@@ -260,9 +277,30 @@ fn run_transition_system(
         let rd = reaching_definitions(&mut joint, st);
         propagate_assignments(&mut joint, st, &rd);
 
-        // put the trace directly into the sim
-        let (_ctx, _sys) = into_transition_system(joint, sys, port_map, port_expr_refs, st);
+        // TODO: This is totally stupid
+        let step_bound = joint.nodes().count() + 1;
+        let (ctx, sys, port_expr_refs) =
+            into_transition_system(joint, sys, port_map, port_expr_refs, st);
 
+        let mut transition_sim = Interpreter::new(&ctx, &sys);
+        transition_sim.init(InitKind::Zero);
+        let mut waveform = FxHashMap::default();
+        for _ in 0..step_bound {
+            record_transition_waveform(&mut waveform, &transition_sim, &port_expr_refs);
+            transition_sim.step();
+        }
+
+        if cli.ascii_waveform {
+            print_trace_success(trace_index);
+            print_ascii_waveform(
+                waveform,
+                |port| sim.port_name(port).to_string(),
+                |port| sim.port_width(port),
+                false,
+            );
+        } else {
+            print_trace_success(trace_index);
+        }
     }
 }
 

--- a/graph-interp/src/main.rs
+++ b/graph-interp/src/main.rs
@@ -1,4 +1,4 @@
-use baa::Value as BaaValue;
+use baa::{BitVecOps, Value as BaaValue};
 use clap::Parser;
 use patronus::expr::ExprRef;
 use patronus::sim::{InitKind, Interpreter, Simulator};
@@ -127,13 +127,26 @@ fn record_transition_waveform(
     waveform: &mut FxHashMap<PortId, Vec<WaveValue>>,
     sim: &Interpreter,
     port_expr_refs: &FxHashMap<PortId, ExprRef>,
+    is_dont_care: &FxHashMap<PortId, ExprRef>,
 ) {
     for (port, expr) in port_expr_refs {
-        let value = match sim.get(*expr) {
-            BaaValue::BitVec(value) => WaveValue::Concrete(value),
-            BaaValue::Array(_) => panic!("DUT ports should be bit-vectors"),
+        let value = if let Some(is_dont_care) = is_dont_care.get(port)
+            && matches!(sim.get(*is_dont_care), BaaValue::BitVec(value) if value.is_one())
+        {
+            WaveValue::DontCare
+        } else {
+            match sim.get(*expr) {
+                BaaValue::BitVec(value) => WaveValue::Concrete(value),
+                BaaValue::Array(_) => panic!("DUT ports should be bit-vectors"),
+            }
         };
         waveform.entry(*port).or_default().push(value);
+    }
+}
+
+fn pop_transition_waveform(waveform: &mut FxHashMap<PortId, Vec<WaveValue>>) {
+    for values in waveform.values_mut() {
+        values.pop();
     }
 }
 
@@ -281,15 +294,21 @@ fn run_transition_system(
         let res = into_transition_system(joint, sys, port_map, port_expr_refs, st);
 
         let mut transition_sim = Interpreter::new(&res.ctx, &res.ts);
-        transition_sim.init(InitKind::Random(0));
+        transition_sim.init(InitKind::Zero);
         let mut waveform = FxHashMap::default();
         loop {
-            record_transition_waveform(&mut waveform, &transition_sim, &res.port_to_expr);
+            record_transition_waveform(
+                &mut waveform,
+                &transition_sim,
+                &res.port_to_expr,
+                &res.is_dont_care,
+            );
             transition_sim.step();
 
             let state = transition_sim.get(res.node_symbol);
             // println!("{:?}", state);
             if state == transition_sim.get(res.done_state.unwrap()) {
+                pop_transition_waveform(&mut waveform);
                 print_trace_success(trace_index);
                 break;
             } else if state == transition_sim.get(res.external_assert_state) {

--- a/graph-interp/src/main.rs
+++ b/graph-interp/src/main.rs
@@ -281,14 +281,14 @@ fn run_transition_system(
         let res = into_transition_system(joint, sys, port_map, port_expr_refs, st);
 
         let mut transition_sim = Interpreter::new(&res.ctx, &res.ts);
-        transition_sim.init(InitKind::Zero);
+        transition_sim.init(InitKind::Random(0));
         let mut waveform = FxHashMap::default();
         loop {
             record_transition_waveform(&mut waveform, &transition_sim, &res.port_to_expr);
             transition_sim.step();
 
             let state = transition_sim.get(res.node_symbol);
-            println!("{:?}", state);
+            // println!("{:?}", state);
             if state == transition_sim.get(res.done_state.unwrap()) {
                 print_trace_success(trace_index);
                 break;

--- a/graph-interp/src/main.rs
+++ b/graph-interp/src/main.rs
@@ -1,5 +1,5 @@
-use clap::Parser;
 use baa::Value as BaaValue;
+use clap::Parser;
 use patronus::expr::ExprRef;
 use patronus::sim::{InitKind, Interpreter, Simulator};
 use protocols::ascii_waveform::print_ascii_waveform;
@@ -8,6 +8,7 @@ use protocols::frontend::ast::{Ast, Protocol};
 use protocols::frontend::design::{Design, find_a_single_design};
 use protocols::frontend::diagnostic::DiagnosticHandler;
 use protocols::frontend::symbol::SymbolTable;
+use protocols::interpreter::Value as WaveValue;
 use protocols::ir::determinize::determinized;
 use protocols::ir::edge_contract::contract_edges;
 use protocols::ir::graph_interpreter;
@@ -17,7 +18,6 @@ use protocols::ir::propagate_assigns::propagate_assignments;
 use protocols::ir::proto_graph::ProtoGraph;
 use protocols::ir::reaching_defs::{format_reaching_defs, reaching_definitions};
 use protocols::ir::trace_lowering::lower_trace_to_ir;
-use protocols::interpreter::Value as WaveValue;
 use protocols::{PatronusSim, PortId, Value, frontend, transaction_frontend};
 use rustc_hash::FxHashMap;
 use std::panic::{AssertUnwindSafe, catch_unwind};
@@ -278,28 +278,36 @@ fn run_transition_system(
         propagate_assignments(&mut joint, st, &rd);
 
         // TODO: This is totally stupid
-        let step_bound = joint.nodes().count() + 1;
-        let (ctx, sys, port_expr_refs) =
-            into_transition_system(joint, sys, port_map, port_expr_refs, st);
+        let res = into_transition_system(joint, sys, port_map, port_expr_refs, st);
 
-        let mut transition_sim = Interpreter::new(&ctx, &sys);
+        let mut transition_sim = Interpreter::new(&res.ctx, &res.ts);
         transition_sim.init(InitKind::Zero);
         let mut waveform = FxHashMap::default();
-        for _ in 0..step_bound {
-            record_transition_waveform(&mut waveform, &transition_sim, &port_expr_refs);
+        loop {
+            record_transition_waveform(&mut waveform, &transition_sim, &res.port_to_expr);
             transition_sim.step();
+
+            let state = transition_sim.get(res.node_symbol);
+            println!("{:?}", state);
+            if state == transition_sim.get(res.done_state.unwrap()) {
+                print_trace_success(trace_index);
+                break;
+            } else if state == transition_sim.get(res.external_assert_state) {
+                println!("Assertion failure.");
+                break;
+            } else if state == transition_sim.get(res.internal_assert_state) {
+                println!("Internal assertion failure.");
+                break;
+            }
         }
 
         if cli.ascii_waveform {
-            print_trace_success(trace_index);
             print_ascii_waveform(
                 waveform,
                 |port| sim.port_name(port).to_string(),
                 |port| sim.port_width(port),
                 false,
             );
-        } else {
-            print_trace_success(trace_index);
         }
     }
 }

--- a/graph-interp/src/main.rs
+++ b/graph-interp/src/main.rs
@@ -144,12 +144,6 @@ fn record_transition_waveform(
     }
 }
 
-fn pop_transition_waveform(waveform: &mut FxHashMap<PortId, Vec<WaveValue>>) {
-    for values in waveform.values_mut() {
-        values.pop();
-    }
-}
-
 /// lower each protocol once and interpret every
 /// transaction against its own symbolic protocol graph.
 fn run_classic(
@@ -290,12 +284,13 @@ fn run_transition_system(
         let rd = reaching_definitions(&mut joint, st);
         propagate_assignments(&mut joint, st, &rd);
 
-        // TODO: This is totally stupid
         let res = into_transition_system(joint, sys, port_map, port_expr_refs, st);
 
         let mut transition_sim = Interpreter::new(&res.ctx, &res.ts);
+        // TODO: once the PatronusSim switches to random, so should we
         transition_sim.init(InitKind::Zero);
         let mut waveform = FxHashMap::default();
+        let mut cycle = 0;
         loop {
             record_transition_waveform(
                 &mut waveform,
@@ -308,16 +303,21 @@ fn run_transition_system(
             let state = transition_sim.get(res.node_symbol);
             // println!("{:?}", state);
             if state == transition_sim.get(res.done_state.unwrap()) {
-                pop_transition_waveform(&mut waveform);
+                // ignore the last cycle (we went one cycle too far)
+                for values in waveform.values_mut() {
+                    values.pop();
+                }
+
                 print_trace_success(trace_index);
                 break;
             } else if state == transition_sim.get(res.external_assert_state) {
-                println!("Assertion failure.");
+                println!("Assertion failure in cycle {}.", cycle);
                 break;
             } else if state == transition_sim.get(res.internal_assert_state) {
-                println!("Internal assertion failure.");
+                println!("Internal assertion failure in cycle {}", cycle);
                 break;
             }
+            cycle += 1;
         }
 
         if cli.ascii_waveform {

--- a/graph-interp/src/main.rs
+++ b/graph-interp/src/main.rs
@@ -1,7 +1,8 @@
 use std::panic::{AssertUnwindSafe, catch_unwind};
-
 use clap::Parser;
+use patronus::expr::ExprRef;
 use protocols::ascii_waveform::print_ascii_waveform;
+use protocols::backends::into_transition_system;
 use protocols::frontend::ast::{Ast, Protocol};
 use protocols::frontend::design::{Design, find_a_single_design};
 use protocols::frontend::diagnostic::DiagnosticHandler;
@@ -15,7 +16,7 @@ use protocols::ir::propagate_assigns::propagate_assignments;
 use protocols::ir::proto_graph::ProtoGraph;
 use protocols::ir::reaching_defs::{format_reaching_defs, reaching_definitions};
 use protocols::ir::trace_lowering::lower_trace_to_ir;
-use protocols::{PatronusSim, Value, frontend, transaction_frontend};
+use protocols::{PatronusSim, Value, frontend, transaction_frontend, PortId};
 use rustc_hash::FxHashMap;
 
 #[derive(Parser, Debug)]
@@ -67,6 +68,9 @@ struct Cli {
     /// Print reaching definition analysis results
     #[arg(long)]
     reaching_definitions: bool,
+
+    #[arg(long)]
+    transition_system: bool,
 }
 
 fn load_protocols(cli: &Cli) -> Ast {
@@ -182,7 +186,7 @@ fn run_respect_forks(
         print_trace_separator(trace_index);
         let mut sim = PatronusSim::new(&cli.verilog, cli.module.as_deref(), design, None).unwrap();
 
-        let mut joint = lower_trace_to_ir(trace, &protos_by_name, st);
+        let mut joint = lower_trace_to_ir(trace, &protos_by_name, st, sim.ctx.clone());
 
         if cli.graphout {
             println!("// joint graph for trace {trace_index}");
@@ -229,6 +233,39 @@ fn run_respect_forks(
     }
 }
 
+fn run_transition_system(
+    cli: &Cli,
+    st: &SymbolTable,
+    protos: &[Protocol],
+    design: &Design,
+    traces: &[Vec<(String, Vec<Value>)>],
+) {
+    // TODO: Duplicate lowering process as respect forks
+    let protos_by_name: FxHashMap<&str, &Protocol> =
+        protos.iter().map(|p| (p.name.as_str(), p)).collect();
+
+    for (trace_index, trace) in traces.iter().enumerate() {
+        print_trace_separator(trace_index);
+        // jankily reuse the sim to get all the stuff we need
+        let sim = PatronusSim::new(&cli.verilog, cli.module.as_deref(), design, None).unwrap();
+        let sys = sim.sys.clone();
+        let port_map = sim.port_map.clone();
+        let port_expr_refs: FxHashMap<PortId, ExprRef> = FxHashMap::from_iter(
+            sim.inputs()
+                .filter_map(|input| sim.get_port_expr(input).map(|expr| (input, expr))),
+        );
+
+        let mut joint = lower_trace_to_ir(trace, &protos_by_name, st, sim.ctx.clone());
+        joint = determinized(joint, st);
+        let rd = reaching_definitions(&mut joint, st);
+        propagate_assignments(&mut joint, st, &rd);
+
+        // put the trace directly into the sim
+        let (_ctx, _sys) = into_transition_system(joint, sys, port_map, port_expr_refs, st);
+
+    }
+}
+
 fn main() {
     let cli = Cli::parse();
     let ast = load_protocols(&cli);
@@ -239,7 +276,9 @@ fn main() {
     let old_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(|_| {}));
     let result = catch_unwind(AssertUnwindSafe(|| {
-        if cli.respect_forks {
+        if cli.transition_system {
+            run_transition_system(&cli, st, &ast.protos, &design, &traces);
+        } else if cli.respect_forks {
             run_respect_forks(&cli, st, &ast.protos, &design, &traces);
         } else {
             run_classic(&cli, st, &ast.protos, &design, traces);

--- a/protocols/src/backends.rs
+++ b/protocols/src/backends.rs
@@ -1,8 +1,8 @@
 // Copyright 2026 Cornell University
 // released under MIT License
 // author: Kevin Laeufer <laeufer@cornell.edu>
-mod verilog;
 mod patronus_trace;
+mod verilog;
 
 pub use patronus_trace::into_transition_system;
 pub use verilog::{PinAnnotation, to_verilog};

--- a/protocols/src/backends.rs
+++ b/protocols/src/backends.rs
@@ -1,8 +1,8 @@
 // Copyright 2026 Cornell University
 // released under MIT License
 // author: Kevin Laeufer <laeufer@cornell.edu>
-mod patronus_trace;
+mod transition_system;
 mod verilog;
 
-pub use patronus_trace::into_transition_system;
+pub use transition_system::into_transition_system;
 pub use verilog::{PinAnnotation, to_verilog};

--- a/protocols/src/backends.rs
+++ b/protocols/src/backends.rs
@@ -2,5 +2,7 @@
 // released under MIT License
 // author: Kevin Laeufer <laeufer@cornell.edu>
 mod verilog;
+mod patronus_trace;
 
+pub use patronus_trace::into_transition_system;
 pub use verilog::{PinAnnotation, to_verilog};

--- a/protocols/src/backends/patronus_trace.rs
+++ b/protocols/src/backends/patronus_trace.rs
@@ -4,7 +4,7 @@ use crate::frontend::symbol::{SymbolId, SymbolTable};
 use crate::ir::proto_graph::{Assignment, NodeId, Op, ProtoGraph};
 use baa::WidthInt;
 use itertools::Itertools;
-use patronus::expr::{Context, ExprRef, Type, simple_transform_expr};
+use patronus::expr::{Context, ExprRef, SerializableIrNode, Type, simple_transform_expr};
 use patronus::system::{State, TransitionSystem};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::borrow::Cow;
@@ -21,6 +21,7 @@ fn guard_exprs_to_ite(v: Vec<GuardedExpr>, ctx: &mut Context, default: ExprRef) 
         ite = ctx.ite(ge.guard, ge.expr, ite);
     }
 
+    println!("{}", ite.serialize_to_str(ctx));
     ite
 }
 
@@ -139,22 +140,28 @@ fn bind_proto_graph_ports_to_dut(
     }
 }
 
+pub struct LoweredSystemResult {
+    pub ctx: Context,
+    pub ts: TransitionSystem,
+    pub port_to_expr: FxHashMap<PortId, ExprRef>,
+    pub node_symbol: ExprRef,
+    pub done_state: Option<ExprRef>,
+    pub external_assert_state: ExprRef,
+    pub internal_assert_state: ExprRef,
+}
+
 pub fn into_transition_system(
     mut pg: ProtoGraph,
     mut ts: TransitionSystem,
     symbol_to_port: FxHashMap<SymbolId, PortId>,
     port_to_expr: FxHashMap<PortId, ExprRef>,
     st: &SymbolTable,
-) -> (
-    patronus::expr::Context,
-    TransitionSystem,
-    FxHashMap<PortId, ExprRef>,
-) {
+) -> LoweredSystemResult {
     let mut ctx = std::mem::take(&mut pg.expr_ctx);
     let mut port_to_expr = port_to_expr;
     bind_proto_graph_ports_to_dut(&mut pg, &mut ctx, &symbol_to_port, &port_to_expr);
 
-    let node_count = pg.nodes().try_len().unwrap() as u64;
+    let node_count = pg.nodes().try_len().unwrap() as u64 + 2;
     let node_id_width = u64::from(u64::BITS - node_count.leading_zeros());
 
     let s = ctx.string(Cow::from("node"));
@@ -162,20 +169,25 @@ pub fn into_transition_system(
 
     // the initial node state is the entry
     let entry_id = ctx.bit_vec_val(pg.entry.as_u32(), node_id_width);
-    let bad_state_id = ctx.bit_vec_val(pg.next_node_id().as_u32(), node_id_width);
+    let external_bad_state_id = ctx.bit_vec_val(pg.next_node_id().as_u32(), node_id_width);
+    println!("External bad state: {:?}", pg.next_node_id().as_u32());
+    // TODO: is it safe to assume node ids are monotone?
+    let internal_bad_state_id =
+        ctx.bit_vec_val(u32::from(pg.next_node_id().as_u32() + 1), node_id_width);
 
     let mut transitions: Vec<GuardedExpr> = vec![];
     // create the transition function - only use the reachable nodes for efficiency
     let mut q = vec![pg.entry];
     let mut visited: FxHashSet<NodeId> = FxHashSet::default();
     visited.insert(pg.entry);
+    let mut done_node_id = None;
     while let Some(id) = q.pop() {
         let src = ctx.bit_vec_val(id.as_u32(), node_id_width);
+        let node_guard = ctx.equal(node_sym, src);
+
         for (guard, dst_node) in pg[id].transitions.iter().map(|t| (t.guard, t.target)) {
             let dst = ctx.bit_vec_val(dst_node.as_u32(), node_id_width);
 
-            // node_sym == src
-            let node_guard = ctx.equal(node_sym, src);
             // node_sym == src && guard
             let and_guard = ctx.and(node_guard, guard);
 
@@ -190,10 +202,41 @@ pub fn into_transition_system(
                 q.push(dst_node);
             }
         }
+
+        for action in &pg[id].actions {
+            match pg[action.op].clone() {
+                Op::AssertEq(lhs, rhs) => {
+                    let eq = ctx.equal(lhs, rhs);
+                    let assertion_failed = ctx.not(eq);
+                    let action_guard = ctx.and(action.guard, assertion_failed);
+                    let bad_guard = ctx.and(node_guard, action_guard);
+                    transitions.push(GuardedExpr {
+                        guard: bad_guard,
+                        expr: external_bad_state_id,
+                    });
+                }
+                Op::InternalAssertFalse => {
+                    let bad_guard = ctx.and(node_guard, action.guard);
+                    transitions.push(GuardedExpr {
+                        guard: bad_guard,
+                        expr: internal_bad_state_id,
+                    });
+                }
+                Op::Assign(_, _) | Op::Fork | Op::Done => {
+                    done_node_id = Some(src);
+                }
+            }
+        }
     }
 
+    let bad_state_guard = ctx.equal(node_sym, external_bad_state_id);
+    transitions.push(GuardedExpr {
+        guard: bad_state_guard,
+        expr: external_bad_state_id,
+    });
+
     // TODO: ITE form is only equivalent if transition guards out of a node are mutually exclusive
-    let transition_ite = guard_exprs_to_ite(transitions, &mut ctx, bad_state_id);
+    let transition_ite = guard_exprs_to_ite(transitions, &mut ctx, external_bad_state_id);
     // add the "node" state and the transition function for it
     let node_state = State {
         symbol: node_sym,
@@ -236,7 +279,7 @@ pub fn into_transition_system(
                 .next()
                 .unwrap();
 
-            let assignment_ite= assignment_to_ite(
+            let assignment_ite = assignment_to_ite(
                 assignment,
                 &mut ctx,
                 input_dont_care.clone(),
@@ -250,7 +293,9 @@ pub fn into_transition_system(
         }
 
         // replace the input ExprRef with the input_ite everywhere
-        let input_expr_ref = *port_to_expr.get(symbol_to_port.get(&input).unwrap()).unwrap();
+        let input_expr_ref = *port_to_expr
+            .get(symbol_to_port.get(&input).unwrap())
+            .unwrap();
         replace_expr_uses(&mut ts, &mut ctx, input_expr_ref, input_ite);
         for expr in port_to_expr.values_mut() {
             *expr = replace_expr(&mut ctx, *expr, input_expr_ref, input_ite);
@@ -258,5 +303,13 @@ pub fn into_transition_system(
     }
 
     ts.add_state(&ctx, node_state);
-    (ctx, ts, port_to_expr)
+    LoweredSystemResult {
+        ctx,
+        ts,
+        port_to_expr,
+        node_symbol: node_sym,
+        done_state: done_node_id,
+        external_assert_state: external_bad_state_id,
+        internal_assert_state: internal_bad_state_id,
+    }
 }

--- a/protocols/src/backends/patronus_trace.rs
+++ b/protocols/src/backends/patronus_trace.rs
@@ -1,0 +1,60 @@
+use std::borrow::Cow;
+use baa::WidthInt;
+use itertools::Itertools;
+use patronus::expr::{ExprRef, Type};
+use patronus::system::{TransitionSystem, State};
+use rustc_hash::FxHashMap;
+use crate::frontend::symbol::{SymbolId, SymbolTable};
+use crate::ir::proto_graph::ProtoGraph;
+use crate::PortId;
+
+struct NodeTransition {
+    pub guard: ExprRef,
+    pub src: ExprRef,
+    pub dst: ExprRef,
+}
+
+pub fn into_transition_system(
+    mut pg: ProtoGraph,
+    mut ts: TransitionSystem,
+    symbol_to_port: FxHashMap<SymbolId, PortId>,
+    port_to_expr: FxHashMap<PortId, ExprRef>,
+    st: &SymbolTable,
+) -> (patronus::expr::Context, TransitionSystem) {
+    let mut ctx = std::mem::take(&mut pg.expr_ctx);
+
+    let node_count = pg.nodes().try_len().unwrap() as u64;
+    let width = u64::from(u64::BITS - node_count.leading_zeros());
+
+    let s = ctx.string(Cow::from("node"));
+    let node_sym = ctx.symbol(s, Type::BV(width as WidthInt));
+
+    // the initial node state is the entry
+    let entry_id = ctx.bit_vec_val(
+        pg.entry.as_u32(),
+        width
+    );
+
+    let mut transitions: Vec<NodeTransition> = vec![];
+    // create the transition function - only use the reachable nodes for efficiency
+    let mut q = vec![pg.entry];
+    while let Some(id) = q.pop() {
+        let src = ctx.bit_vec_val(id.as_u32(), width);
+        for (guard, dst_node) in pg[id].transitions.iter().map(|t| (t.guard, t.target)) {
+            let dst = ctx.bit_vec_val(dst_node.as_u32(), width);
+
+            let t = NodeTransition { guard, src , dst};
+            transitions.push(t);
+        }
+    }
+
+    // add the "node" state and the transition function for it
+    let node_state = State {
+        symbol: node_sym,
+        init: Some(entry_id),
+        next: None,
+    };
+
+    ts.add_state(&ctx, node_state);
+    (ctx, ts)
+}

--- a/protocols/src/backends/patronus_trace.rs
+++ b/protocols/src/backends/patronus_trace.rs
@@ -1,17 +1,142 @@
-use std::borrow::Cow;
+use crate::PortId;
+use crate::frontend::symbol;
+use crate::frontend::symbol::{SymbolId, SymbolTable};
+use crate::ir::proto_graph::{Assignment, NodeId, Op, ProtoGraph};
 use baa::WidthInt;
 use itertools::Itertools;
-use patronus::expr::{ExprRef, Type};
-use patronus::system::{TransitionSystem, State};
-use rustc_hash::FxHashMap;
-use crate::frontend::symbol::{SymbolId, SymbolTable};
-use crate::ir::proto_graph::ProtoGraph;
-use crate::PortId;
+use patronus::expr::{Context, ExprRef, Type, simple_transform_expr};
+use patronus::system::{State, TransitionSystem};
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::borrow::Cow;
 
-struct NodeTransition {
+struct GuardedExpr {
     pub guard: ExprRef,
-    pub src: ExprRef,
-    pub dst: ExprRef,
+    pub expr: ExprRef,
+}
+
+fn guard_exprs_to_ite(v: Vec<GuardedExpr>, ctx: &mut Context, default: ExprRef) -> ExprRef {
+    let mut ite = default;
+
+    for ge in v {
+        ite = ctx.ite(ge.guard, ge.expr, ite);
+    }
+
+    ite
+}
+
+fn assignment_to_ite(
+    a: Assignment,
+    ctx: &mut Context,
+    dont_care: ExprRef,
+    default: ExprRef,
+) -> ExprRef {
+    let mut ite = default;
+
+    for (guard, expr) in a.concretes {
+        ite = ctx.ite(guard, expr, ite);
+    }
+
+    ite = ctx.ite(a.dont_care, dont_care, ite);
+
+    ite
+}
+
+fn replace_expr(ctx: &mut Context, expr: ExprRef, old_expr: ExprRef, new_expr: ExprRef) -> ExprRef {
+    simple_transform_expr(ctx, expr, |_ctx, candidate, _children| {
+        (candidate == old_expr).then_some(new_expr)
+    })
+}
+
+fn replace_expr_uses(
+    ts: &mut TransitionSystem,
+    ctx: &mut Context,
+    old_expr: ExprRef,
+    new_expr: ExprRef,
+) {
+    let mut replace = |expr| replace_expr(ctx, expr, old_expr, new_expr);
+
+    for constraint in &mut ts.constraints {
+        *constraint = replace(*constraint);
+    }
+
+    for bad_state in &mut ts.bad_states {
+        *bad_state = replace(*bad_state);
+    }
+
+    for output in &mut ts.outputs {
+        output.expr = replace(output.expr);
+    }
+
+    for state in &mut ts.states {
+        state.init = state.init.map(&mut replace);
+        state.next = state.next.map(&mut replace);
+    }
+}
+
+fn replace_proto_graph_exprs(
+    pg: &mut ProtoGraph,
+    ctx: &mut Context,
+    old_expr: ExprRef,
+    new_expr: ExprRef,
+) {
+    for (_, node) in pg.nodes_mut() {
+        for action in &mut node.actions {
+            action.guard = replace_expr(ctx, action.guard, old_expr, new_expr);
+        }
+
+        for transition in &mut node.transitions {
+            transition.guard = replace_expr(ctx, transition.guard, old_expr, new_expr);
+        }
+    }
+
+    for (_, op) in pg.ops_mut() {
+        match op {
+            Op::Assign(_, assignment) => {
+                assignment.dont_care = replace_expr(ctx, assignment.dont_care, old_expr, new_expr);
+                for (guard, rhs) in &mut assignment.concretes {
+                    *guard = replace_expr(ctx, *guard, old_expr, new_expr);
+                    *rhs = replace_expr(ctx, *rhs, old_expr, new_expr);
+                }
+            }
+            Op::AssertEq(lhs, rhs) => {
+                *lhs = replace_expr(ctx, *lhs, old_expr, new_expr);
+                *rhs = replace_expr(ctx, *rhs, old_expr, new_expr);
+            }
+            Op::Fork | Op::InternalAssertFalse | Op::Done => {}
+        }
+    }
+
+    for expr in pg.symbol_expr.values_mut() {
+        *expr = replace_expr(ctx, *expr, old_expr, new_expr);
+    }
+
+    let dont_cares = std::mem::take(&mut pg.dont_cares);
+    pg.dont_cares = dont_cares
+        .into_iter()
+        .map(|expr| replace_expr(ctx, expr, old_expr, new_expr))
+        .collect();
+}
+
+fn bind_proto_graph_ports_to_dut(
+    pg: &mut ProtoGraph,
+    ctx: &mut Context,
+    symbol_to_port: &FxHashMap<SymbolId, PortId>,
+    port_to_expr: &FxHashMap<PortId, ExprRef>,
+) {
+    let port_bindings: Vec<_> = pg
+        .symbol_expr
+        .iter()
+        .filter_map(|(symbol_id, graph_expr)| {
+            let port = symbol_to_port.get(symbol_id)?;
+            let dut_expr = port_to_expr.get(port)?;
+            Some((*graph_expr, *dut_expr))
+        })
+        .filter(|(graph_expr, dut_expr)| graph_expr != dut_expr)
+        .collect();
+
+    for (graph_expr, dut_expr) in port_bindings {
+        replace_proto_graph_exprs(pg, ctx, graph_expr, dut_expr);
+    }
 }
 
 pub fn into_transition_system(
@@ -20,41 +145,118 @@ pub fn into_transition_system(
     symbol_to_port: FxHashMap<SymbolId, PortId>,
     port_to_expr: FxHashMap<PortId, ExprRef>,
     st: &SymbolTable,
-) -> (patronus::expr::Context, TransitionSystem) {
+) -> (
+    patronus::expr::Context,
+    TransitionSystem,
+    FxHashMap<PortId, ExprRef>,
+) {
     let mut ctx = std::mem::take(&mut pg.expr_ctx);
+    let mut port_to_expr = port_to_expr;
+    bind_proto_graph_ports_to_dut(&mut pg, &mut ctx, &symbol_to_port, &port_to_expr);
 
     let node_count = pg.nodes().try_len().unwrap() as u64;
-    let width = u64::from(u64::BITS - node_count.leading_zeros());
+    let node_id_width = u64::from(u64::BITS - node_count.leading_zeros());
 
     let s = ctx.string(Cow::from("node"));
-    let node_sym = ctx.symbol(s, Type::BV(width as WidthInt));
+    let node_sym = ctx.symbol(s, Type::BV(node_id_width as WidthInt));
 
     // the initial node state is the entry
-    let entry_id = ctx.bit_vec_val(
-        pg.entry.as_u32(),
-        width
-    );
+    let entry_id = ctx.bit_vec_val(pg.entry.as_u32(), node_id_width);
+    let bad_state_id = ctx.bit_vec_val(pg.next_node_id().as_u32(), node_id_width);
 
-    let mut transitions: Vec<NodeTransition> = vec![];
+    let mut transitions: Vec<GuardedExpr> = vec![];
     // create the transition function - only use the reachable nodes for efficiency
     let mut q = vec![pg.entry];
+    let mut visited: FxHashSet<NodeId> = FxHashSet::default();
+    visited.insert(pg.entry);
     while let Some(id) = q.pop() {
-        let src = ctx.bit_vec_val(id.as_u32(), width);
+        let src = ctx.bit_vec_val(id.as_u32(), node_id_width);
         for (guard, dst_node) in pg[id].transitions.iter().map(|t| (t.guard, t.target)) {
-            let dst = ctx.bit_vec_val(dst_node.as_u32(), width);
+            let dst = ctx.bit_vec_val(dst_node.as_u32(), node_id_width);
 
-            let t = NodeTransition { guard, src , dst};
+            // node_sym == src
+            let node_guard = ctx.equal(node_sym, src);
+            // node_sym == src && guard
+            let and_guard = ctx.and(node_guard, guard);
+
+            let t = GuardedExpr {
+                guard: and_guard,
+                expr: dst,
+            };
             transitions.push(t);
+
+            if !visited.contains(&dst_node) {
+                visited.insert(dst_node);
+                q.push(dst_node);
+            }
         }
     }
 
+    // TODO: ITE form is only equivalent if transition guards out of a node are mutually exclusive
+    let transition_ite = guard_exprs_to_ite(transitions, &mut ctx, bad_state_id);
     // add the "node" state and the transition function for it
     let node_state = State {
         symbol: node_sym,
         init: Some(entry_id),
-        next: None,
+        next: Some(transition_ite),
     };
 
+    // set up ITE expressions based on what node state we're in for each port,
+    // and replace the inputs with the ITEs everywhere
+    // TODO: is this the correct way to get ports here
+    let input_symbols: Vec<SymbolId> = st
+        .get_children(&pg.proto_ctx.type_param.unwrap())
+        .into_iter()
+        .filter(|sym_id| st[*sym_id].is_in_port())
+        .collect();
+
+    // TODO: this can be done as a single pass over nodes, instead of two loops
+    for input in input_symbols.clone() {
+        let tpe = st[input].tpe();
+        let input_width = match tpe {
+            symbol::Type::BitVec(width) => width,
+            _ => panic!("unsupported input port type"),
+        };
+
+        let dont_care_name = format!("dont_care.{}", st.full_name_from_symbol_id(&input));
+        let input_dont_care = ctx.bv_symbol(&dont_care_name, input_width as WidthInt);
+        ts.add_input(&ctx, input_dont_care);
+
+        // TODO: idk what to make the default. right now just the dont care?
+        let mut input_ite = input_dont_care;
+        // TODO: This iteration is unwieldy
+        for id in visited.clone().drain() {
+            let assignment: Assignment = pg[id]
+                .actions
+                .iter()
+                .filter_map(|action| match pg[action.op].clone() {
+                    Op::Assign(assigned_input, expr) if assigned_input == input => Some(expr),
+                    _ => None,
+                })
+                .next()
+                .unwrap();
+
+            let assignment_ite= assignment_to_ite(
+                assignment,
+                &mut ctx,
+                input_dont_care.clone(),
+                input_dont_care.clone(),
+            );
+
+            let node_id_expr = ctx.bit_vec_val(id.as_u32(), node_id_width);
+            let node_equals = ctx.equal(node_sym, node_id_expr);
+
+            input_ite = ctx.ite(node_equals, assignment_ite, input_ite);
+        }
+
+        // replace the input ExprRef with the input_ite everywhere
+        let input_expr_ref = *port_to_expr.get(symbol_to_port.get(&input).unwrap()).unwrap();
+        replace_expr_uses(&mut ts, &mut ctx, input_expr_ref, input_ite);
+        for expr in port_to_expr.values_mut() {
+            *expr = replace_expr(&mut ctx, *expr, input_expr_ref, input_ite);
+        }
+    }
+
     ts.add_state(&ctx, node_state);
-    (ctx, ts)
+    (ctx, ts, port_to_expr)
 }

--- a/protocols/src/backends/transition_system.rs
+++ b/protocols/src/backends/transition_system.rs
@@ -4,7 +4,7 @@ use crate::frontend::symbol::{SymbolId, SymbolTable};
 use crate::ir::proto_graph::{Assignment, NodeId, Op, ProtoGraph};
 use baa::WidthInt;
 use itertools::Itertools;
-use patronus::expr::{Context, ExprRef, SerializableIrNode, Type, simple_transform_expr};
+use patronus::expr::{Context, ExprRef, Type, simple_transform_expr};
 use patronus::system::{State, TransitionSystem};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::borrow::Cow;
@@ -21,7 +21,7 @@ fn guard_exprs_to_ite(v: Vec<GuardedExpr>, ctx: &mut Context, default: ExprRef) 
         ite = ctx.ite(ge.guard, ge.expr, ite);
     }
 
-    println!("{}", ite.serialize_to_str(ctx));
+    // println!("{}", ite.serialize_to_str(ctx));
     ite
 }
 
@@ -170,10 +170,9 @@ pub fn into_transition_system(
     // the initial node state is the entry
     let entry_id = ctx.bit_vec_val(pg.entry.as_u32(), node_id_width);
     let external_bad_state_id = ctx.bit_vec_val(pg.next_node_id().as_u32(), node_id_width);
-    println!("External bad state: {:?}", pg.next_node_id().as_u32());
+    // println!("External bad state: {:?}", pg.next_node_id().as_u32());
     // TODO: is it safe to assume node ids are monotone?
-    let internal_bad_state_id =
-        ctx.bit_vec_val(u32::from(pg.next_node_id().as_u32() + 1), node_id_width);
+    let internal_bad_state_id = ctx.bit_vec_val(pg.next_node_id().as_u32() + 1, node_id_width);
 
     let mut transitions: Vec<GuardedExpr> = vec![];
     // create the transition function - only use the reachable nodes for efficiency
@@ -203,6 +202,8 @@ pub fn into_transition_system(
             }
         }
 
+        // these need to come later in the vector so they are preferred in the ITE
+        // i.e. assertions are checked before transitions
         for action in &pg[id].actions {
             match pg[action.op].clone() {
                 Op::AssertEq(lhs, rhs) => {
@@ -279,12 +280,8 @@ pub fn into_transition_system(
                 .next()
                 .unwrap();
 
-            let assignment_ite = assignment_to_ite(
-                assignment,
-                &mut ctx,
-                input_dont_care.clone(),
-                input_dont_care.clone(),
-            );
+            let assignment_ite =
+                assignment_to_ite(assignment, &mut ctx, input_dont_care, input_dont_care);
 
             let node_id_expr = ctx.bit_vec_val(id.as_u32(), node_id_width);
             let node_equals = ctx.equal(node_sym, node_id_expr);

--- a/protocols/src/backends/transition_system.rs
+++ b/protocols/src/backends/transition_system.rs
@@ -55,17 +55,11 @@ fn assignment_to_ite(
     ite
 }
 
-/// return an expression which is `true` iff the `Assignment` `a` evals to DontCare
-fn assignment_to_dont_care_ite(a: &Assignment, ctx: &mut Context, default: ExprRef) -> ExprRef {
-    let mut ite = default;
-    let false_id = ctx.get_false();
-    let true_id = ctx.get_true();
-
-    for (guard, _) in &a.concretes {
-        ite = ctx.ite(*guard, false_id, ite);
-    }
-
-    ctx.ite(a.dont_care, true_id, ite)
+/// return an expression which is `true` iff some branch of `Assignment` `a` triggers
+fn assignment_is_triggered(a: &Assignment, ctx: &mut Context) -> ExprRef {
+    a.concretes
+        .iter()
+        .fold(a.dont_care, |acc, (guard, _)| ctx.or(acc, *guard))
 }
 
 fn replace_expr(ctx: &mut Context, expr: ExprRef, old_expr: ExprRef, new_expr: ExprRef) -> ExprRef {
@@ -344,11 +338,18 @@ pub fn into_transition_system(
                 .next()
                 .unwrap();
 
-            let default_is_dont_care = ctx.get_true();
-            let assignment_is_dont_care =
-                assignment_to_dont_care_ite(&assignment, &mut ctx, default_is_dont_care);
-            // TODO: setting the default to the input itself (just stays its current value)
-            // TODO: but we should transition to the internal bad state if no assignment triggers
+            let assignment_is_dont_care = assignment.dont_care;
+            let assignment_is_triggered = assignment_is_triggered(&assignment, &mut ctx);
+            let assignment_not_triggered = ctx.not(assignment_is_triggered);
+
+            // if an assignment isn't triggered, go to the bad state
+            let input_assignment_failed = ctx.and(node_equals, assignment_not_triggered);
+            transition_ite = ctx.ite(
+                input_assignment_failed,
+                internal_bad_state_id,
+                transition_ite,
+            );
+
             let assignment_ite = assignment_to_ite(
                 assignment,
                 &mut ctx,

--- a/protocols/src/backends/transition_system.rs
+++ b/protocols/src/backends/transition_system.rs
@@ -9,16 +9,30 @@ use patronus::system::{State, TransitionSystem};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::borrow::Cow;
 
-struct GuardedExpr {
-    pub guard: ExprRef,
-    pub expr: ExprRef,
+/// the first part of an ITE: the if condition, and the then expression
+struct IfThenExpr {
+    pub if_cond: ExprRef,
+    pub then: ExprRef,
 }
 
-fn guard_exprs_to_ite(v: Vec<GuardedExpr>, ctx: &mut Context, default: ExprRef) -> ExprRef {
+struct InputDriver {
+    port: PortId,
+    input_expr_ref: ExprRef,
+    /// the port's value expression
+    input_ite: ExprRef,
+    /// the condition under which the input resolved to DontCare
+    /// this is used for pretty printing the ASCII waveform
+    input_is_dont_care: ExprRef,
+    /// The corresponding input to the transition system, invoked on a DontCare assignment
+    input_dont_care: ExprRef,
+}
+
+/// Turn a vector of `IfThenExpr`s, with *Right-to-Left* priority, into an ITE with default `default`
+fn if_thens_to_ite(v: Vec<IfThenExpr>, ctx: &mut Context, default: ExprRef) -> ExprRef {
     let mut ite = default;
 
     for ge in v {
-        ite = ctx.ite(ge.guard, ge.expr, ite);
+        ite = ctx.ite(ge.if_cond, ge.then, ite);
     }
 
     ite
@@ -41,6 +55,7 @@ fn assignment_to_ite(
     ite
 }
 
+/// return an expression which is `true` iff the `Assignment` `a` evals to DontCare
 fn assignment_to_dont_care_ite(a: &Assignment, ctx: &mut Context, default: ExprRef) -> ExprRef {
     let mut ite = default;
     let false_id = ctx.get_false();
@@ -129,6 +144,8 @@ fn replace_proto_graph_exprs(
         .collect();
 }
 
+/// swap out all the ports in the ProtoGraph with their equivalents
+/// in the DUT
 fn bind_proto_graph_ports_to_dut(
     pg: &mut ProtoGraph,
     ctx: &mut Context,
@@ -188,12 +205,15 @@ pub fn into_transition_system(
     let internal_bad_state_id = ctx.bit_vec_val(pg.next_node_id().as_u32() + 1, node_id_width);
     let done_state_id = ctx.bit_vec_val(pg.next_node_id().as_u32() + 2, node_id_width);
 
-    let mut transitions: Vec<GuardedExpr> = vec![];
+    // Generate a big vector of all the transitions
+    let mut transitions: Vec<IfThenExpr> = vec![];
     // create the transition function - only use the reachable nodes for efficiency
     let mut q = vec![pg.entry];
     let mut visited: FxHashSet<NodeId> = FxHashSet::default();
     visited.insert(pg.entry);
+    let mut reachable_nodes = Vec::new();
     while let Some(id) = q.pop() {
+        reachable_nodes.push(id);
         let src = ctx.bit_vec_val(id.as_u32(), node_id_width);
         let node_guard = ctx.equal(node_sym, src);
 
@@ -202,9 +222,9 @@ pub fn into_transition_system(
         for action in &pg[id].actions {
             if matches!(pg[action.op], Op::Done) {
                 let done_guard = ctx.and(node_guard, action.guard);
-                transitions.push(GuardedExpr {
-                    guard: done_guard,
-                    expr: done_state_id,
+                transitions.push(IfThenExpr {
+                    if_cond: done_guard,
+                    then: done_state_id,
                 });
             }
         }
@@ -215,9 +235,9 @@ pub fn into_transition_system(
             // node_sym == src && guard
             let and_guard = ctx.and(node_guard, guard);
 
-            let t = GuardedExpr {
-                guard: and_guard,
-                expr: dst,
+            let t = IfThenExpr {
+                if_cond: and_guard,
+                then: dst,
             };
             transitions.push(t);
 
@@ -236,16 +256,16 @@ pub fn into_transition_system(
                     let assertion_failed = ctx.not(eq);
                     let action_guard = ctx.and(action.guard, assertion_failed);
                     let bad_guard = ctx.and(node_guard, action_guard);
-                    transitions.push(GuardedExpr {
-                        guard: bad_guard,
-                        expr: external_bad_state_id,
+                    transitions.push(IfThenExpr {
+                        if_cond: bad_guard,
+                        then: external_bad_state_id,
                     });
                 }
                 Op::InternalAssertFalse => {
                     let bad_guard = ctx.and(node_guard, action.guard);
-                    transitions.push(GuardedExpr {
-                        guard: bad_guard,
-                        expr: internal_bad_state_id,
+                    transitions.push(IfThenExpr {
+                        if_cond: bad_guard,
+                        then: internal_bad_state_id,
                     });
                 }
                 Op::Assign(_, _) | Op::Fork | Op::Done => {}
@@ -254,34 +274,36 @@ pub fn into_transition_system(
     }
 
     let done_state_guard = ctx.equal(node_sym, done_state_id);
-    transitions.push(GuardedExpr {
-        guard: done_state_guard,
-        expr: done_state_id,
+    transitions.push(IfThenExpr {
+        if_cond: done_state_guard,
+        then: done_state_id,
     });
     let external_bad_state_guard = ctx.equal(node_sym, external_bad_state_id);
-    transitions.push(GuardedExpr {
-        guard: external_bad_state_guard,
-        expr: external_bad_state_id,
+    transitions.push(IfThenExpr {
+        if_cond: external_bad_state_guard,
+        then: external_bad_state_id,
     });
     let internal_bad_state_guard = ctx.equal(node_sym, internal_bad_state_id);
-    transitions.push(GuardedExpr {
-        guard: internal_bad_state_guard,
-        expr: internal_bad_state_id,
+    transitions.push(IfThenExpr {
+        if_cond: internal_bad_state_guard,
+        then: internal_bad_state_id,
     });
 
-    let mut transition_ite = guard_exprs_to_ite(transitions, &mut ctx, external_bad_state_id);
+    // if no transition is satisfied, we go to the internal bad state
+    // the final done state self-loops, so it won't trigger this
+    let mut transition_ite = if_thens_to_ite(transitions, &mut ctx, internal_bad_state_id);
 
     // set up ITE expressions based on what node state we're in for each port,
     // and replace the inputs with the ITEs everywhere
-    // TODO: is this the correct way to get ports here?
     let input_symbols: Vec<SymbolId> = st
         .get_children(&pg.proto_ctx.type_param.unwrap())
         .into_iter()
         .filter(|sym_id| st[*sym_id].is_in_port())
         .collect();
 
-    // TODO: this can be done as a single pass over nodes, instead of two loops
-    for input in input_symbols.clone() {
+    // set up default input drivers per input
+    let mut input_drivers = Vec::with_capacity(input_symbols.len());
+    for input in input_symbols {
         let tpe = st[input].tpe();
         let input_width = match tpe {
             symbol::Type::BitVec(width) => width,
@@ -292,16 +314,31 @@ pub fn into_transition_system(
         let input_dont_care = ctx.bv_symbol(&dont_care_name, input_width as WidthInt);
         ts.add_input(&ctx, input_dont_care);
 
-        // TODO: idk what to make the default. right now just the dont care?
-        let mut input_ite = input_dont_care;
-        let mut input_is_dont_care = ctx.get_true();
-        // TODO: This iteration is unwieldy
-        for id in visited.clone().drain() {
+        let input_port = *symbol_to_port.get(&input).unwrap();
+        let input_expr_ref = *port_to_expr.get(&input_port).unwrap();
+        input_drivers.push((
+            input,
+            InputDriver {
+                port: input_port,
+                input_expr_ref,
+                input_ite: input_dont_care,
+                input_is_dont_care: ctx.get_true(),
+                input_dont_care,
+            },
+        ));
+    }
+
+    // populate the input drivers with assignments in the reachable nodes
+    for id in reachable_nodes {
+        let node_id_expr = ctx.bit_vec_val(id.as_u32(), node_id_width);
+        let node_equals = ctx.equal(node_sym, node_id_expr);
+
+        for (input, driver) in &mut input_drivers {
             let assignment: Assignment = pg[id]
                 .actions
                 .iter()
                 .filter_map(|action| match pg[action.op].clone() {
-                    Op::Assign(assigned_input, expr) if assigned_input == input => Some(expr),
+                    Op::Assign(assigned_input, expr) if assigned_input == *input => Some(expr),
                     _ => None,
                 })
                 .next()
@@ -310,25 +347,37 @@ pub fn into_transition_system(
             let default_is_dont_care = ctx.get_true();
             let assignment_is_dont_care =
                 assignment_to_dont_care_ite(&assignment, &mut ctx, default_is_dont_care);
-            let assignment_ite =
-                assignment_to_ite(assignment, &mut ctx, input_dont_care, input_dont_care);
+            // TODO: setting the default to the input itself (just stays its current value)
+            // TODO: but we should transition to the internal bad state if no assignment triggers
+            let assignment_ite = assignment_to_ite(
+                assignment,
+                &mut ctx,
+                driver.input_dont_care,
+                driver.input_expr_ref,
+            );
 
-            let node_id_expr = ctx.bit_vec_val(id.as_u32(), node_id_width);
-            let node_equals = ctx.equal(node_sym, node_id_expr);
-
-            input_ite = ctx.ite(node_equals, assignment_ite, input_ite);
-            input_is_dont_care = ctx.ite(node_equals, assignment_is_dont_care, input_is_dont_care);
+            driver.input_ite = ctx.ite(node_equals, assignment_ite, driver.input_ite);
+            driver.input_is_dont_care = ctx.ite(
+                node_equals,
+                assignment_is_dont_care,
+                driver.input_is_dont_care,
+            );
         }
+    }
 
-        // replace the input ExprRef with the input_ite everywhere
-        let input_port = *symbol_to_port.get(&input).unwrap();
-        let input_expr_ref = *port_to_expr.get(&input_port).unwrap();
-        replace_expr_uses(&mut ts, &mut ctx, input_expr_ref, input_ite);
-        transition_ite = replace_expr(&mut ctx, transition_ite, input_expr_ref, input_ite);
+    // replace the input ExprRef with the input_ite everywhere
+    for (_, driver) in input_drivers {
+        replace_expr_uses(&mut ts, &mut ctx, driver.input_expr_ref, driver.input_ite);
+        transition_ite = replace_expr(
+            &mut ctx,
+            transition_ite,
+            driver.input_expr_ref,
+            driver.input_ite,
+        );
         for expr in port_to_expr.values_mut() {
-            *expr = replace_expr(&mut ctx, *expr, input_expr_ref, input_ite);
+            *expr = replace_expr(&mut ctx, *expr, driver.input_expr_ref, driver.input_ite);
         }
-        is_dont_care.insert(input_port, input_is_dont_care);
+        is_dont_care.insert(driver.port, driver.input_is_dont_care);
     }
 
     let node_state = State {

--- a/protocols/src/backends/transition_system.rs
+++ b/protocols/src/backends/transition_system.rs
@@ -42,6 +42,18 @@ fn assignment_to_ite(
     ite
 }
 
+fn assignment_to_dont_care_ite(a: &Assignment, ctx: &mut Context, default: ExprRef) -> ExprRef {
+    let mut ite = default;
+    let false_id = ctx.get_false();
+    let true_id = ctx.get_true();
+
+    for (guard, _) in &a.concretes {
+        ite = ctx.ite(*guard, false_id, ite);
+    }
+
+    ctx.ite(a.dont_care, true_id, ite)
+}
+
 fn replace_expr(ctx: &mut Context, expr: ExprRef, old_expr: ExprRef, new_expr: ExprRef) -> ExprRef {
     simple_transform_expr(ctx, expr, |_ctx, candidate, _children| {
         (candidate == old_expr).then_some(new_expr)
@@ -148,6 +160,7 @@ pub struct LoweredSystemResult {
     pub done_state: Option<ExprRef>,
     pub external_assert_state: ExprRef,
     pub internal_assert_state: ExprRef,
+    pub is_dont_care: FxHashMap<PortId, ExprRef>,
 }
 
 pub fn into_transition_system(
@@ -159,9 +172,10 @@ pub fn into_transition_system(
 ) -> LoweredSystemResult {
     let mut ctx = std::mem::take(&mut pg.expr_ctx);
     let mut port_to_expr = port_to_expr;
+    let mut is_dont_care = FxHashMap::default();
     bind_proto_graph_ports_to_dut(&mut pg, &mut ctx, &symbol_to_port, &port_to_expr);
 
-    let node_count = pg.nodes().try_len().unwrap() as u64 + 2;
+    let node_count = pg.nodes().try_len().unwrap() as u64 + 3;
     let node_id_width = u64::from(u64::BITS - node_count.leading_zeros());
 
     let s = ctx.string(Cow::from("node"));
@@ -173,16 +187,28 @@ pub fn into_transition_system(
     // println!("External bad state: {:?}", pg.next_node_id().as_u32());
     // TODO: is it safe to assume node ids are monotone?
     let internal_bad_state_id = ctx.bit_vec_val(pg.next_node_id().as_u32() + 1, node_id_width);
+    let done_state_id = ctx.bit_vec_val(pg.next_node_id().as_u32() + 2, node_id_width);
 
     let mut transitions: Vec<GuardedExpr> = vec![];
     // create the transition function - only use the reachable nodes for efficiency
     let mut q = vec![pg.entry];
     let mut visited: FxHashSet<NodeId> = FxHashSet::default();
     visited.insert(pg.entry);
-    let mut done_node_id = None;
     while let Some(id) = q.pop() {
         let src = ctx.bit_vec_val(id.as_u32(), node_id_width);
         let node_guard = ctx.equal(node_sym, src);
+
+        // Done has lower priority than graph transitions. Since later ITE arms
+        // win, emit done transitions before normal transitions.
+        for action in &pg[id].actions {
+            if matches!(pg[action.op], Op::Done) {
+                let done_guard = ctx.and(node_guard, action.guard);
+                transitions.push(GuardedExpr {
+                    guard: done_guard,
+                    expr: done_state_id,
+                });
+            }
+        }
 
         for (guard, dst_node) in pg[id].transitions.iter().map(|t| (t.guard, t.target)) {
             let dst = ctx.bit_vec_val(dst_node.as_u32(), node_id_width);
@@ -223,17 +249,25 @@ pub fn into_transition_system(
                         expr: internal_bad_state_id,
                     });
                 }
-                Op::Assign(_, _) | Op::Fork | Op::Done => {
-                    done_node_id = Some(src);
-                }
+                Op::Assign(_, _) | Op::Fork | Op::Done => {}
             }
         }
     }
 
-    let bad_state_guard = ctx.equal(node_sym, external_bad_state_id);
+    let done_state_guard = ctx.equal(node_sym, done_state_id);
     transitions.push(GuardedExpr {
-        guard: bad_state_guard,
+        guard: done_state_guard,
+        expr: done_state_id,
+    });
+    let external_bad_state_guard = ctx.equal(node_sym, external_bad_state_id);
+    transitions.push(GuardedExpr {
+        guard: external_bad_state_guard,
         expr: external_bad_state_id,
+    });
+    let internal_bad_state_guard = ctx.equal(node_sym, internal_bad_state_id);
+    transitions.push(GuardedExpr {
+        guard: internal_bad_state_guard,
+        expr: internal_bad_state_id,
     });
 
     // TODO: ITE form is only equivalent if transition guards out of a node are mutually exclusive
@@ -268,6 +302,7 @@ pub fn into_transition_system(
 
         // TODO: idk what to make the default. right now just the dont care?
         let mut input_ite = input_dont_care;
+        let mut input_is_dont_care = ctx.get_true();
         // TODO: This iteration is unwieldy
         for id in visited.clone().drain() {
             let assignment: Assignment = pg[id]
@@ -280,6 +315,9 @@ pub fn into_transition_system(
                 .next()
                 .unwrap();
 
+            let default_is_dont_care = ctx.get_true();
+            let assignment_is_dont_care =
+                assignment_to_dont_care_ite(&assignment, &mut ctx, default_is_dont_care);
             let assignment_ite =
                 assignment_to_ite(assignment, &mut ctx, input_dont_care, input_dont_care);
 
@@ -287,16 +325,18 @@ pub fn into_transition_system(
             let node_equals = ctx.equal(node_sym, node_id_expr);
 
             input_ite = ctx.ite(node_equals, assignment_ite, input_ite);
+            input_is_dont_care =
+                ctx.ite(node_equals, assignment_is_dont_care, input_is_dont_care);
         }
 
         // replace the input ExprRef with the input_ite everywhere
-        let input_expr_ref = *port_to_expr
-            .get(symbol_to_port.get(&input).unwrap())
-            .unwrap();
+        let input_port = *symbol_to_port.get(&input).unwrap();
+        let input_expr_ref = *port_to_expr.get(&input_port).unwrap();
         replace_expr_uses(&mut ts, &mut ctx, input_expr_ref, input_ite);
         for expr in port_to_expr.values_mut() {
             *expr = replace_expr(&mut ctx, *expr, input_expr_ref, input_ite);
         }
+        is_dont_care.insert(input_port, input_is_dont_care);
     }
 
     ts.add_state(&ctx, node_state);
@@ -305,8 +345,9 @@ pub fn into_transition_system(
         ts,
         port_to_expr,
         node_symbol: node_sym,
-        done_state: done_node_id,
+        done_state: Some(done_state_id),
         external_assert_state: external_bad_state_id,
         internal_assert_state: internal_bad_state_id,
+        is_dont_care,
     }
 }

--- a/protocols/src/backends/transition_system.rs
+++ b/protocols/src/backends/transition_system.rs
@@ -21,7 +21,6 @@ fn guard_exprs_to_ite(v: Vec<GuardedExpr>, ctx: &mut Context, default: ExprRef) 
         ite = ctx.ite(ge.guard, ge.expr, ite);
     }
 
-    // println!("{}", ite.serialize_to_str(ctx));
     ite
 }
 
@@ -184,7 +183,7 @@ pub fn into_transition_system(
     // the initial node state is the entry
     let entry_id = ctx.bit_vec_val(pg.entry.as_u32(), node_id_width);
     let external_bad_state_id = ctx.bit_vec_val(pg.next_node_id().as_u32(), node_id_width);
-    // println!("External bad state: {:?}", pg.next_node_id().as_u32());
+
     // TODO: is it safe to assume node ids are monotone?
     let internal_bad_state_id = ctx.bit_vec_val(pg.next_node_id().as_u32() + 1, node_id_width);
     let done_state_id = ctx.bit_vec_val(pg.next_node_id().as_u32() + 2, node_id_width);
@@ -270,18 +269,11 @@ pub fn into_transition_system(
         expr: internal_bad_state_id,
     });
 
-    // TODO: ITE form is only equivalent if transition guards out of a node are mutually exclusive
-    let transition_ite = guard_exprs_to_ite(transitions, &mut ctx, external_bad_state_id);
-    // add the "node" state and the transition function for it
-    let node_state = State {
-        symbol: node_sym,
-        init: Some(entry_id),
-        next: Some(transition_ite),
-    };
+    let mut transition_ite = guard_exprs_to_ite(transitions, &mut ctx, external_bad_state_id);
 
     // set up ITE expressions based on what node state we're in for each port,
     // and replace the inputs with the ITEs everywhere
-    // TODO: is this the correct way to get ports here
+    // TODO: is this the correct way to get ports here?
     let input_symbols: Vec<SymbolId> = st
         .get_children(&pg.proto_ctx.type_param.unwrap())
         .into_iter()
@@ -325,20 +317,25 @@ pub fn into_transition_system(
             let node_equals = ctx.equal(node_sym, node_id_expr);
 
             input_ite = ctx.ite(node_equals, assignment_ite, input_ite);
-            input_is_dont_care =
-                ctx.ite(node_equals, assignment_is_dont_care, input_is_dont_care);
+            input_is_dont_care = ctx.ite(node_equals, assignment_is_dont_care, input_is_dont_care);
         }
 
         // replace the input ExprRef with the input_ite everywhere
         let input_port = *symbol_to_port.get(&input).unwrap();
         let input_expr_ref = *port_to_expr.get(&input_port).unwrap();
         replace_expr_uses(&mut ts, &mut ctx, input_expr_ref, input_ite);
+        transition_ite = replace_expr(&mut ctx, transition_ite, input_expr_ref, input_ite);
         for expr in port_to_expr.values_mut() {
             *expr = replace_expr(&mut ctx, *expr, input_expr_ref, input_ite);
         }
         is_dont_care.insert(input_port, input_is_dont_care);
     }
 
+    let node_state = State {
+        symbol: node_sym,
+        init: Some(entry_id),
+        next: Some(transition_ite),
+    };
     ts.add_state(&ctx, node_state);
     LoweredSystemResult {
         ctx,

--- a/protocols/src/dut.rs
+++ b/protocols/src/dut.rs
@@ -26,19 +26,19 @@ const EMPTY_PORT_VEC: Vec<PortId> = vec![];
 const EMPTY_PORT_VEC_REF: &Vec<PortId> = &EMPTY_PORT_VEC;
 
 pub struct PatronusSim {
-    ctx: patronus::expr::Context,
-    sys: TransitionSystem,
-    sim: Interpreter,
-    port_map: FxHashMap<SymbolId, PortId>,
+    pub ctx: patronus::expr::Context,
+    pub sys: TransitionSystem,
+    pub sim: Interpreter,
+    pub port_map: FxHashMap<SymbolId, PortId>,
     // Combinational dependency tracking
     /// Maps `input |-> Vec<output>` (outputs that are affected by this input)
     input_dependencies: FxHashMap<PortId, Vec<PortId>>,
     /// Maps each `output |-> Vec<input>` (inputs that this output is dependent on)
     output_dependencies: FxHashMap<PortId, Vec<PortId>>,
     /// easy access to valid input ports
-    inputs: Vec<PortId>,
+    pub inputs: Vec<PortId>,
     /// easy access to valid output ports
-    outputs: Vec<PortId>,
+    pub outputs: Vec<PortId>,
 }
 
 /// Prototype of our generic (non-patronus specific) dut simulator  interface
@@ -242,7 +242,7 @@ impl PatronusSim {
         }
     }
 
-    fn get_port_expr(&self, port: PortId) -> Option<ExprRef> {
+    pub fn get_port_expr(&self, port: PortId) -> Option<ExprRef> {
         self.get_input(port)
             .or_else(|| self.get_output(port).map(|o| o.expr))
     }

--- a/protocols/src/ir/lowering.rs
+++ b/protocols/src/ir/lowering.rs
@@ -2,7 +2,7 @@
 // released under MIT License
 // author: Nikil Shyamunder <nvs26@cornell.edu>
 
-use patronus::expr::{ExprRef, Type as PatronusType};
+use patronus::expr::{ExprRef, Type as PatronusType, Context as ExprContext};
 use rustc_hash::FxHashMap;
 
 use crate::frontend::ast::{BinOp, Expr, ExprId, Protocol, ProtocolContext, Stmt, StmtId, UnaryOp};
@@ -36,6 +36,15 @@ impl<'a> Lowerer<'a> {
     pub fn new(ctx: ProtocolContext, symbols: &'a SymbolTable) -> Self {
         Self {
             ir: ProtoGraph::new(ctx),
+            symbols,
+            trace_arg_subst: TraceArgSubst::default(),
+            current_fragment_nodes: Vec::new(),
+        }
+    }
+
+    pub fn with_expr_ctx(ctx: ProtocolContext, symbols: &'a SymbolTable, expr_ctx: ExprContext) -> Self {
+        Self {
+            ir: ProtoGraph::with_expr_ctx(ctx, expr_ctx),
             symbols,
             trace_arg_subst: TraceArgSubst::default(),
             current_fragment_nodes: Vec::new(),

--- a/protocols/src/ir/lowering.rs
+++ b/protocols/src/ir/lowering.rs
@@ -2,7 +2,7 @@
 // released under MIT License
 // author: Nikil Shyamunder <nvs26@cornell.edu>
 
-use patronus::expr::{ExprRef, Type as PatronusType, Context as ExprContext};
+use patronus::expr::{Context as ExprContext, ExprRef, Type as PatronusType};
 use rustc_hash::FxHashMap;
 
 use crate::frontend::ast::{BinOp, Expr, ExprId, Protocol, ProtocolContext, Stmt, StmtId, UnaryOp};
@@ -42,7 +42,11 @@ impl<'a> Lowerer<'a> {
         }
     }
 
-    pub fn with_expr_ctx(ctx: ProtocolContext, symbols: &'a SymbolTable, expr_ctx: ExprContext) -> Self {
+    pub fn with_expr_ctx(
+        ctx: ProtocolContext,
+        symbols: &'a SymbolTable,
+        expr_ctx: ExprContext,
+    ) -> Self {
         Self {
             ir: ProtoGraph::with_expr_ctx(ctx, expr_ctx),
             symbols,

--- a/protocols/src/ir/proto_graph.rs
+++ b/protocols/src/ir/proto_graph.rs
@@ -284,6 +284,14 @@ impl ProtoGraph {
         self.nodes.iter()
     }
 
+    pub fn nodes_mut(&mut self) -> impl Iterator<Item = (NodeId, &mut Node)> + '_ {
+        self.nodes.iter_mut()
+    }
+
+    pub fn ops_mut(&mut self) -> impl Iterator<Item = (OpId, &mut Op)> + '_ {
+        self.ops.iter_mut()
+    }
+
     pub fn node_mut(&mut self, node_id: NodeId) -> &mut Node {
         &mut self.nodes[node_id]
     }

--- a/protocols/src/ir/proto_graph.rs
+++ b/protocols/src/ir/proto_graph.rs
@@ -171,7 +171,10 @@ impl Clone for ProtoGraph {
 
 impl ProtoGraph {
     pub fn new(proto_ctx: ProtocolContext) -> Self {
-        let expr_ctx = ExprContext::default();
+        Self::with_expr_ctx(proto_ctx, ExprContext::default())
+    }
+
+    pub fn with_expr_ctx(proto_ctx: ProtocolContext, expr_ctx: ExprContext) -> Self {
         let mut nodes = PrimaryMap::new();
         let entry = Node::empty();
         let entry_id: NodeId = nodes.push(entry);

--- a/protocols/src/ir/trace_lowering.rs
+++ b/protocols/src/ir/trace_lowering.rs
@@ -13,6 +13,7 @@ use crate::ir::edge_contract::{append_action, contract_edges, guard_assignment};
 use crate::ir::fork_reach::{ForkReachability, reaching_forks_from};
 use crate::ir::lowering::{LoweredFragmentInfo, Lowerer, TraceArgSubst};
 use crate::ir::proto_graph::{Action, NodeId, Op, ProtoGraph, Transition};
+use patronus::expr::Context as ExprContext;
 
 impl<'a> Lowerer<'a> {
     /// Build the per-copy argument substitution and lower one transaction body.
@@ -197,6 +198,7 @@ pub fn lower_trace_to_ir(
     trace: &[(String, Vec<Value>)],
     protos_by_name: &FxHashMap<&str, &Protocol>,
     symbols: &SymbolTable,
+    expr_ctx: ExprContext,
 ) -> ProtoGraph {
     assert!(!trace.is_empty(), "cannot lower an empty trace");
 
@@ -206,7 +208,7 @@ pub fn lower_trace_to_ir(
         .unwrap_or_else(|| panic!("unknown protocol {first_name}"));
 
     // set up the lowerer and lower the initial transaction
-    let mut lowerer = Lowerer::new(first_ast.ctx.clone(), symbols);
+    let mut lowerer = Lowerer::with_expr_ctx(first_ast.ctx.clone(), symbols, expr_ctx);
     let first = lowerer.lower_transaction(first_ast, first_values, trace.len() == 1);
     let entry_node = lowerer.ir.entry;
     let true_id = lowerer.ir.true_id();

--- a/runt/waveform/runt.toml
+++ b/runt/waveform/runt.toml
@@ -19,6 +19,15 @@ expect_name = "unsigned_mul.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions examples/picorv32/unsigned_mul.tx --respect-forks --determinize --ascii-waveform --verilog examples/picorv32/picorv32.v --protocol examples/picorv32/pcpi_mul.prot --module picorv32_pcpi_mul 2>/dev/null"
 
 [[tests]]
+name = "waveform.examples_picorv32_unsigned_mul.unsigned_mul_waveform.ts"
+paths = [
+  "../../examples/picorv32/unsigned_mul.tx",
+]
+expect_dir = "../../examples/picorv32/expects"
+expect_name = "unsigned_mul.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions examples/picorv32/unsigned_mul.tx --transition-system --ascii-waveform --verilog examples/picorv32/picorv32.v --protocol examples/picorv32/pcpi_mul.prot --module picorv32_pcpi_mul 2>/dev/null"
+
+[[tests]]
 name = "waveform.examples_serv_serv_regfile.serv_regfile_waveform.ast"
 paths = [
   "../../examples/serv/serv_regfile.tx",
@@ -35,6 +44,15 @@ paths = [
 expect_dir = "../../examples/serv/expects"
 expect_name = "serv_regfile.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions examples/serv/serv_regfile.tx --respect-forks --determinize --ascii-waveform --verilog examples/serv/rtl/serv_regfile.v --protocol examples/serv/serv_regfile.prot 2>/dev/null"
+
+[[tests]]
+name = "waveform.examples_serv_serv_regfile.serv_regfile_waveform.ts"
+paths = [
+  "../../examples/serv/serv_regfile.tx",
+]
+expect_dir = "../../examples/serv/expects"
+expect_name = "serv_regfile.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions examples/serv/serv_regfile.tx --transition-system --ascii-waveform --verilog examples/serv/rtl/serv_regfile.v --protocol examples/serv/serv_regfile.prot 2>/dev/null"
 
 [[tests]]
 name = "waveform.examples_tinyaes128_aes128.aes128_waveform.ast"
@@ -55,6 +73,15 @@ expect_name = "aes128.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions examples/tinyaes128/aes128.tx --respect-forks --determinize --ascii-waveform --verilog examples/tinyaes128/aes_128.v --protocol examples/tinyaes128/aes128.prot --module aes_128 2>/dev/null"
 
 [[tests]]
+name = "waveform.examples_tinyaes128_aes128.aes128_waveform.ts"
+paths = [
+  "../../examples/tinyaes128/aes128.tx",
+]
+expect_dir = "../../examples/tinyaes128/expects"
+expect_name = "aes128.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions examples/tinyaes128/aes128.tx --transition-system --ascii-waveform --verilog examples/tinyaes128/aes_128.v --protocol examples/tinyaes128/aes128.prot --module aes_128 2>/dev/null"
+
+[[tests]]
 name = "waveform.tests_adders_adder_d0_add_combinational.add_combinational_waveform.ast"
 paths = [
   "../../tests/adders/adder_d0/add_combinational.tx",
@@ -71,6 +98,15 @@ paths = [
 expect_dir = "../../tests/adders/adder_d0/expects"
 expect_name = "add_combinational.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions tests/adders/adder_d0/add_combinational.tx --respect-forks --determinize --ascii-waveform --verilog tests/adders/adder_d0/add_d0.v --protocol tests/adders/adder_d0/add_d0.prot 2>/dev/null"
+
+[[tests]]
+name = "waveform.tests_adders_adder_d0_add_combinational.add_combinational_waveform.ts"
+paths = [
+  "../../tests/adders/adder_d0/add_combinational.tx",
+]
+expect_dir = "../../tests/adders/adder_d0/expects"
+expect_name = "add_combinational.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions tests/adders/adder_d0/add_combinational.tx --transition-system --ascii-waveform --verilog tests/adders/adder_d0/add_d0.v --protocol tests/adders/adder_d0/add_d0.prot 2>/dev/null"
 
 [[tests]]
 name = "waveform.tests_adders_adder_d1_add_multitrace_successful.add_multitrace_successful_waveform.ast"
@@ -91,6 +127,15 @@ expect_name = "add_multitrace_successful.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions tests/adders/adder_d1/add_multitrace_successful.tx --respect-forks --determinize --ascii-waveform --verilog tests/adders/adder_d1/add_d1.v --protocol tests/adders/adder_d1/add_d1.prot 2>/dev/null"
 
 [[tests]]
+name = "waveform.tests_adders_adder_d1_add_multitrace_successful.add_multitrace_successful_waveform.ts"
+paths = [
+  "../../tests/adders/adder_d1/add_multitrace_successful.tx",
+]
+expect_dir = "../../tests/adders/adder_d1/expects"
+expect_name = "add_multitrace_successful.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions tests/adders/adder_d1/add_multitrace_successful.tx --transition-system --ascii-waveform --verilog tests/adders/adder_d1/add_d1.v --protocol tests/adders/adder_d1/add_d1.prot 2>/dev/null"
+
+[[tests]]
 name = "waveform.tests_adders_adder_d1_both_threads_pass.both_threads_pass_waveform.ast"
 paths = [
   "../../tests/adders/adder_d1/both_threads_pass.tx",
@@ -107,6 +152,15 @@ paths = [
 expect_dir = "../../tests/adders/adder_d1/expects"
 expect_name = "both_threads_pass.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions tests/adders/adder_d1/both_threads_pass.tx --respect-forks --determinize --ascii-waveform --verilog tests/adders/adder_d1/add_d1.v --protocol tests/adders/adder_d1/add_d1.prot 2>/dev/null"
+
+[[tests]]
+name = "waveform.tests_adders_adder_d1_both_threads_pass.both_threads_pass_waveform.ts"
+paths = [
+  "../../tests/adders/adder_d1/both_threads_pass.tx",
+]
+expect_dir = "../../tests/adders/adder_d1/expects"
+expect_name = "both_threads_pass.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions tests/adders/adder_d1/both_threads_pass.tx --transition-system --ascii-waveform --verilog tests/adders/adder_d1/add_d1.v --protocol tests/adders/adder_d1/add_d1.prot 2>/dev/null"
 
 [[tests]]
 name = "waveform.tests_adders_adder_d2_both_threads_pass.both_threads_pass_waveform.ast"
@@ -127,6 +181,15 @@ expect_name = "both_threads_pass.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions tests/adders/adder_d2/both_threads_pass.tx --respect-forks --determinize --ascii-waveform --verilog tests/adders/adder_d2/add_d2.v --protocol tests/adders/adder_d2/add_d2.prot 2>/dev/null"
 
 [[tests]]
+name = "waveform.tests_adders_adder_d2_both_threads_pass.both_threads_pass_waveform.ts"
+paths = [
+  "../../tests/adders/adder_d2/both_threads_pass.tx",
+]
+expect_dir = "../../tests/adders/adder_d2/expects"
+expect_name = "both_threads_pass.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions tests/adders/adder_d2/both_threads_pass.tx --transition-system --ascii-waveform --verilog tests/adders/adder_d2/add_d2.v --protocol tests/adders/adder_d2/add_d2.prot 2>/dev/null"
+
+[[tests]]
 name = "waveform.tests_alus_alu_d1.alu_d1_waveform.ast"
 paths = [
   "../../tests/alus/alu_d1.tx",
@@ -143,6 +206,15 @@ paths = [
 expect_dir = "../../tests/alus/expects"
 expect_name = "alu_d1.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions tests/alus/alu_d1.tx --respect-forks --determinize --ascii-waveform --verilog tests/alus/alu_d1.v --protocol tests/alus/alu_d1.prot --module alu_d1 2>/dev/null"
+
+[[tests]]
+name = "waveform.tests_alus_alu_d1.alu_d1_waveform.ts"
+paths = [
+  "../../tests/alus/alu_d1.tx",
+]
+expect_dir = "../../tests/alus/expects"
+expect_name = "alu_d1.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions tests/alus/alu_d1.tx --transition-system --ascii-waveform --verilog tests/alus/alu_d1.v --protocol tests/alus/alu_d1.prot --module alu_d1 2>/dev/null"
 
 [[tests]]
 name = "waveform.tests_alus_alu_d2.alu_d2_waveform.ast"
@@ -163,6 +235,15 @@ expect_name = "alu_d2.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions tests/alus/alu_d2.tx --respect-forks --determinize --ascii-waveform --verilog tests/alus/alu_d2.v --protocol tests/alus/alu_d2.prot --module alu_d2 2>/dev/null"
 
 [[tests]]
+name = "waveform.tests_alus_alu_d2.alu_d2_waveform.ts"
+paths = [
+  "../../tests/alus/alu_d2.tx",
+]
+expect_dir = "../../tests/alus/expects"
+expect_name = "alu_d2.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions tests/alus/alu_d2.tx --transition-system --ascii-waveform --verilog tests/alus/alu_d2.v --protocol tests/alus/alu_d2.prot --module alu_d2 2>/dev/null"
+
+[[tests]]
 name = "waveform.tests_bounded_ready_valid_toy_reciever_0.toy_reciever_0_waveform.ast"
 paths = [
   "../../tests/bounded_ready_valid/toy_reciever_0.tx",
@@ -179,6 +260,15 @@ paths = [
 expect_dir = "../../tests/bounded_ready_valid/expects"
 expect_name = "toy_reciever_0.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions tests/bounded_ready_valid/toy_reciever_0.tx --respect-forks --determinize --ascii-waveform --verilog tests/bounded_ready_valid/toy_receiver_0.v --protocol tests/bounded_ready_valid/bounded_rv.prot 2>/dev/null"
+
+[[tests]]
+name = "waveform.tests_bounded_ready_valid_toy_reciever_0.toy_reciever_0_waveform.ts"
+paths = [
+  "../../tests/bounded_ready_valid/toy_reciever_0.tx",
+]
+expect_dir = "../../tests/bounded_ready_valid/expects"
+expect_name = "toy_reciever_0.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions tests/bounded_ready_valid/toy_reciever_0.tx --transition-system --ascii-waveform --verilog tests/bounded_ready_valid/toy_receiver_0.v --protocol tests/bounded_ready_valid/bounded_rv.prot 2>/dev/null"
 
 [[tests]]
 name = "waveform.tests_bounded_ready_valid_toy_reciever_1.toy_reciever_1_waveform.ast"
@@ -199,6 +289,15 @@ expect_name = "toy_reciever_1.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions tests/bounded_ready_valid/toy_reciever_1.tx --respect-forks --determinize --ascii-waveform --verilog tests/bounded_ready_valid/toy_receiver_1.v --protocol tests/bounded_ready_valid/bounded_rv.prot 2>/dev/null"
 
 [[tests]]
+name = "waveform.tests_bounded_ready_valid_toy_reciever_1.toy_reciever_1_waveform.ts"
+paths = [
+  "../../tests/bounded_ready_valid/toy_reciever_1.tx",
+]
+expect_dir = "../../tests/bounded_ready_valid/expects"
+expect_name = "toy_reciever_1.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions tests/bounded_ready_valid/toy_reciever_1.tx --transition-system --ascii-waveform --verilog tests/bounded_ready_valid/toy_receiver_1.v --protocol tests/bounded_ready_valid/bounded_rv.prot 2>/dev/null"
+
+[[tests]]
 name = "waveform.tests_bounded_ready_valid_toy_reciever_2.toy_reciever_2_waveform.ast"
 paths = [
   "../../tests/bounded_ready_valid/toy_reciever_2.tx",
@@ -215,6 +314,15 @@ paths = [
 expect_dir = "../../tests/bounded_ready_valid/expects"
 expect_name = "toy_reciever_2.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions tests/bounded_ready_valid/toy_reciever_2.tx --respect-forks --determinize --ascii-waveform --verilog tests/bounded_ready_valid/toy_receiver_2.v --protocol tests/bounded_ready_valid/bounded_rv.prot 2>/dev/null"
+
+[[tests]]
+name = "waveform.tests_bounded_ready_valid_toy_reciever_2.toy_reciever_2_waveform.ts"
+paths = [
+  "../../tests/bounded_ready_valid/toy_reciever_2.tx",
+]
+expect_dir = "../../tests/bounded_ready_valid/expects"
+expect_name = "toy_reciever_2.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions tests/bounded_ready_valid/toy_reciever_2.tx --transition-system --ascii-waveform --verilog tests/bounded_ready_valid/toy_receiver_2.v --protocol tests/bounded_ready_valid/bounded_rv.prot 2>/dev/null"
 
 [[tests]]
 name = "waveform.tests_brave_new_world_bit_truncation_bit_truncation_fft_fix.bit_truncation_fft_fix_waveform.ast"
@@ -235,6 +343,15 @@ expect_name = "bit_truncation_fft_fix.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions tests/brave_new_world/bit_truncation/bit_truncation_fft_fix.tx --respect-forks --determinize --ascii-waveform --verilog tests/brave_new_world/bit_truncation/bit_truncation_fft_fix.v --protocol tests/brave_new_world/bit_truncation/bit_truncation_fft.prot --module round11_rne_unsigned_fixed 2>/dev/null"
 
 [[tests]]
+name = "waveform.tests_brave_new_world_bit_truncation_bit_truncation_fft_fix.bit_truncation_fft_fix_waveform.ts"
+paths = [
+  "../../tests/brave_new_world/bit_truncation/bit_truncation_fft_fix.tx",
+]
+expect_dir = "../../tests/brave_new_world/bit_truncation/expects"
+expect_name = "bit_truncation_fft_fix.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions tests/brave_new_world/bit_truncation/bit_truncation_fft_fix.tx --transition-system --ascii-waveform --verilog tests/brave_new_world/bit_truncation/bit_truncation_fft_fix.v --protocol tests/brave_new_world/bit_truncation/bit_truncation_fft.prot --module round11_rne_unsigned_fixed 2>/dev/null"
+
+[[tests]]
 name = "waveform.tests_brave_new_world_bit_truncation_bit_truncation_sha_fix.bit_truncation_sha_fix_waveform.ast"
 paths = [
   "../../tests/brave_new_world/bit_truncation/bit_truncation_sha_fix.tx",
@@ -251,6 +368,15 @@ paths = [
 expect_dir = "../../tests/brave_new_world/bit_truncation/expects"
 expect_name = "bit_truncation_sha_fix.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions tests/brave_new_world/bit_truncation/bit_truncation_sha_fix.tx --respect-forks --determinize --ascii-waveform --verilog tests/brave_new_world/bit_truncation/bit_truncation_sha_fix.v --protocol tests/brave_new_world/bit_truncation/bit_truncation_sha.prot --module bit_truncation_sha_fixed 2>/dev/null"
+
+[[tests]]
+name = "waveform.tests_brave_new_world_bit_truncation_bit_truncation_sha_fix.bit_truncation_sha_fix_waveform.ts"
+paths = [
+  "../../tests/brave_new_world/bit_truncation/bit_truncation_sha_fix.tx",
+]
+expect_dir = "../../tests/brave_new_world/bit_truncation/expects"
+expect_name = "bit_truncation_sha_fix.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions tests/brave_new_world/bit_truncation/bit_truncation_sha_fix.tx --transition-system --ascii-waveform --verilog tests/brave_new_world/bit_truncation/bit_truncation_sha_fix.v --protocol tests/brave_new_world/bit_truncation/bit_truncation_sha.prot --module bit_truncation_sha_fixed 2>/dev/null"
 
 [[tests]]
 name = "waveform.tests_brave_new_world_signal_asynchrony_signal_async_fix.signal_async_fix_waveform.ast"
@@ -271,6 +397,15 @@ expect_name = "signal_async_fix.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions tests/brave_new_world/signal_asynchrony/signal_async_fix.tx --respect-forks --determinize --ascii-waveform --verilog tests/brave_new_world/signal_asynchrony/signal_async_fix.v --protocol tests/brave_new_world/signal_asynchrony/signal_async.prot --module signal_async_fix 2>/dev/null"
 
 [[tests]]
+name = "waveform.tests_brave_new_world_signal_asynchrony_signal_async_fix.signal_async_fix_waveform.ts"
+paths = [
+  "../../tests/brave_new_world/signal_asynchrony/signal_async_fix.tx",
+]
+expect_dir = "../../tests/brave_new_world/signal_asynchrony/expects"
+expect_name = "signal_async_fix.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions tests/brave_new_world/signal_asynchrony/signal_async_fix.tx --transition-system --ascii-waveform --verilog tests/brave_new_world/signal_asynchrony/signal_async_fix.v --protocol tests/brave_new_world/signal_asynchrony/signal_async.prot --module signal_async_fix 2>/dev/null"
+
+[[tests]]
 name = "waveform.tests_brave_new_world_use_without_valid_use_without_valid_fix.use_without_valid_fix_waveform.ast"
 paths = [
   "../../tests/brave_new_world/use_without_valid/use_without_valid_fix.tx",
@@ -287,6 +422,15 @@ paths = [
 expect_dir = "../../tests/brave_new_world/use_without_valid/expects"
 expect_name = "use_without_valid_fix.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions tests/brave_new_world/use_without_valid/use_without_valid_fix.tx --respect-forks --determinize --ascii-waveform --verilog tests/brave_new_world/use_without_valid/use_without_valid_fix.v --protocol tests/brave_new_world/use_without_valid/use_without_valid.prot --module use_without_valid_fix 2>/dev/null"
+
+[[tests]]
+name = "waveform.tests_brave_new_world_use_without_valid_use_without_valid_fix.use_without_valid_fix_waveform.ts"
+paths = [
+  "../../tests/brave_new_world/use_without_valid/use_without_valid_fix.tx",
+]
+expect_dir = "../../tests/brave_new_world/use_without_valid/expects"
+expect_name = "use_without_valid_fix.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions tests/brave_new_world/use_without_valid/use_without_valid_fix.tx --transition-system --ascii-waveform --verilog tests/brave_new_world/use_without_valid/use_without_valid_fix.v --protocol tests/brave_new_world/use_without_valid/use_without_valid.prot --module use_without_valid_fix 2>/dev/null"
 
 [[tests]]
 name = "waveform.tests_counters_counter.counter_waveform.ast"
@@ -307,6 +451,15 @@ expect_name = "counter.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions tests/counters/counter.tx --respect-forks --determinize --ascii-waveform --verilog tests/counters/counter.v --protocol tests/counters/counter.prot 2>/dev/null"
 
 [[tests]]
+name = "waveform.tests_counters_counter.counter_waveform.ts"
+paths = [
+  "../../tests/counters/counter.tx",
+]
+expect_dir = "../../tests/counters/expects"
+expect_name = "counter.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions tests/counters/counter.tx --transition-system --ascii-waveform --verilog tests/counters/counter.v --protocol tests/counters/counter.prot 2>/dev/null"
+
+[[tests]]
 name = "waveform.tests_fifo_fifo.fifo_waveform.ast"
 paths = [
   "../../tests/fifo/fifo.tx",
@@ -323,6 +476,15 @@ paths = [
 expect_dir = "../../tests/fifo/expects"
 expect_name = "fifo.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions tests/fifo/fifo.tx --respect-forks --determinize --ascii-waveform --verilog tests/fifo/bsg_mem_1rw_sync.v tests/fifo/bsg_mem_1rw_sync_synth.v tests/fifo/bsg_circular_ptr.v tests/fifo/bsg_fifo_1rw_large.v tests/fifo/fifo_wrapper.v --protocol tests/fifo/fifo.prot --module fifo_wrapper 2>/dev/null"
+
+[[tests]]
+name = "waveform.tests_fifo_fifo.fifo_waveform.ts"
+paths = [
+  "../../tests/fifo/fifo.tx",
+]
+expect_dir = "../../tests/fifo/expects"
+expect_name = "fifo.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions tests/fifo/fifo.tx --transition-system --ascii-waveform --verilog tests/fifo/bsg_mem_1rw_sync.v tests/fifo/bsg_mem_1rw_sync_synth.v tests/fifo/bsg_circular_ptr.v tests/fifo/bsg_fifo_1rw_large.v tests/fifo/fifo_wrapper.v --protocol tests/fifo/fifo.prot --module fifo_wrapper 2>/dev/null"
 
 [[tests]]
 name = "waveform.tests_fifo_push_pop_identity_ok.push_pop_identity_ok_waveform.ast"
@@ -343,6 +505,15 @@ expect_name = "push_pop_identity_ok.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions tests/fifo/push_pop_identity_ok.tx --respect-forks --determinize --ascii-waveform --verilog tests/fifo/bsg_mem_1rw_sync.v tests/fifo/bsg_mem_1rw_sync_synth.v tests/fifo/bsg_circular_ptr.v tests/fifo/bsg_fifo_1rw_large.v tests/fifo/fifo_wrapper.v --protocol tests/fifo/fifo.prot --module fifo_wrapper 2>/dev/null"
 
 [[tests]]
+name = "waveform.tests_fifo_push_pop_identity_ok.push_pop_identity_ok_waveform.ts"
+paths = [
+  "../../tests/fifo/push_pop_identity_ok.tx",
+]
+expect_dir = "../../tests/fifo/expects"
+expect_name = "push_pop_identity_ok.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions tests/fifo/push_pop_identity_ok.tx --transition-system --ascii-waveform --verilog tests/fifo/bsg_mem_1rw_sync.v tests/fifo/bsg_mem_1rw_sync_synth.v tests/fifo/bsg_circular_ptr.v tests/fifo/bsg_fifo_1rw_large.v tests/fifo/fifo_wrapper.v --protocol tests/fifo/fifo.prot --module fifo_wrapper 2>/dev/null"
+
+[[tests]]
 name = "waveform.tests_identities_identity_d0_passthrough_combdep.passthrough_combdep_waveform.ast"
 paths = [
   "../../tests/identities/identity_d0/passthrough_combdep.tx",
@@ -359,6 +530,15 @@ paths = [
 expect_dir = "../../tests/identities/identity_d0/expects"
 expect_name = "passthrough_combdep.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions tests/identities/identity_d0/passthrough_combdep.tx --respect-forks --determinize --ascii-waveform --verilog tests/identities/identity_d0/identity_d0.v --protocol tests/identities/identity_d0/identity_d0.prot 2>/dev/null"
+
+[[tests]]
+name = "waveform.tests_identities_identity_d0_passthrough_combdep.passthrough_combdep_waveform.ts"
+paths = [
+  "../../tests/identities/identity_d0/passthrough_combdep.tx",
+]
+expect_dir = "../../tests/identities/identity_d0/expects"
+expect_name = "passthrough_combdep.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions tests/identities/identity_d0/passthrough_combdep.tx --transition-system --ascii-waveform --verilog tests/identities/identity_d0/identity_d0.v --protocol tests/identities/identity_d0/identity_d0.prot 2>/dev/null"
 
 [[tests]]
 name = "waveform.tests_identities_identity_d1_slicing_ok.slicing_ok_waveform.ast"
@@ -379,6 +559,15 @@ expect_name = "slicing_ok.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions tests/identities/identity_d1/slicing_ok.tx --respect-forks --determinize --ascii-waveform --verilog tests/identities/identity_d1/identity_d1.v --protocol tests/identities/identity_d1/identity_d1.prot 2>/dev/null"
 
 [[tests]]
+name = "waveform.tests_identities_identity_d1_slicing_ok.slicing_ok_waveform.ts"
+paths = [
+  "../../tests/identities/identity_d1/slicing_ok.tx",
+]
+expect_dir = "../../tests/identities/identity_d1/expects"
+expect_name = "slicing_ok.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions tests/identities/identity_d1/slicing_ok.tx --transition-system --ascii-waveform --verilog tests/identities/identity_d1/identity_d1.v --protocol tests/identities/identity_d1/identity_d1.prot 2>/dev/null"
+
+[[tests]]
 name = "waveform.tests_identities_identity_d2_single_thread_passes.single_thread_passes_waveform.ast"
 paths = [
   "../../tests/identities/identity_d2/single_thread_passes.tx",
@@ -395,6 +584,15 @@ paths = [
 expect_dir = "../../tests/identities/identity_d2/expects"
 expect_name = "single_thread_passes.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions tests/identities/identity_d2/single_thread_passes.tx --respect-forks --determinize --ascii-waveform --verilog tests/identities/identity_d2/identity_d2.v --protocol tests/identities/identity_d2/identity_d2.prot 2>/dev/null"
+
+[[tests]]
+name = "waveform.tests_identities_identity_d2_single_thread_passes.single_thread_passes_waveform.ts"
+paths = [
+  "../../tests/identities/identity_d2/single_thread_passes.tx",
+]
+expect_dir = "../../tests/identities/identity_d2/expects"
+expect_name = "single_thread_passes.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions tests/identities/identity_d2/single_thread_passes.tx --transition-system --ascii-waveform --verilog tests/identities/identity_d2/identity_d2.v --protocol tests/identities/identity_d2/identity_d2.prot 2>/dev/null"
 
 [[tests]]
 name = "waveform.tests_multi_multi0_multi0.multi0_waveform.ast"
@@ -415,6 +613,15 @@ expect_name = "multi0.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions tests/multi/multi0/multi0.tx --respect-forks --determinize --ascii-waveform --verilog tests/multi/multi0/multi0.v --protocol tests/multi/multi0/multi0.prot --module multi0 2>/dev/null"
 
 [[tests]]
+name = "waveform.tests_multi_multi0_multi0.multi0_waveform.ts"
+paths = [
+  "../../tests/multi/multi0/multi0.tx",
+]
+expect_dir = "../../tests/multi/multi0/expects"
+expect_name = "multi0.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions tests/multi/multi0/multi0.tx --transition-system --ascii-waveform --verilog tests/multi/multi0/multi0.v --protocol tests/multi/multi0/multi0.prot --module multi0 2>/dev/null"
+
+[[tests]]
 name = "waveform.tests_multi_multi0keep_multi0keep.multi0keep_waveform.ast"
 paths = [
   "../../tests/multi/multi0keep/multi0keep.tx",
@@ -431,6 +638,15 @@ paths = [
 expect_dir = "../../tests/multi/multi0keep/expects"
 expect_name = "multi0keep.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions tests/multi/multi0keep/multi0keep.tx --respect-forks --determinize --ascii-waveform --verilog tests/multi/multi0keep/multi0keep.v --protocol tests/multi/multi0keep/multi0keep.prot --module multi0keep 2>/dev/null"
+
+[[tests]]
+name = "waveform.tests_multi_multi0keep_multi0keep.multi0keep_waveform.ts"
+paths = [
+  "../../tests/multi/multi0keep/multi0keep.tx",
+]
+expect_dir = "../../tests/multi/multi0keep/expects"
+expect_name = "multi0keep.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions tests/multi/multi0keep/multi0keep.tx --transition-system --ascii-waveform --verilog tests/multi/multi0keep/multi0keep.v --protocol tests/multi/multi0keep/multi0keep.prot --module multi0keep 2>/dev/null"
 
 [[tests]]
 name = "waveform.tests_multi_multi0keep2const_multi0keep2const.multi0keep2const_waveform.ast"
@@ -451,6 +667,15 @@ expect_name = "multi0keep2const.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions tests/multi/multi0keep2const/multi0keep2const.tx --respect-forks --determinize --ascii-waveform --verilog tests/multi/multi0keep2const/multi0keep2const.v tests/multi/multi0keep/multi0keep.v --protocol tests/multi/multi0keep2const/multi0keep2const.prot --module multi0keep2const 2>/dev/null"
 
 [[tests]]
+name = "waveform.tests_multi_multi0keep2const_multi0keep2const.multi0keep2const_waveform.ts"
+paths = [
+  "../../tests/multi/multi0keep2const/multi0keep2const.tx",
+]
+expect_dir = "../../tests/multi/multi0keep2const/expects"
+expect_name = "multi0keep2const.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions tests/multi/multi0keep2const/multi0keep2const.tx --transition-system --ascii-waveform --verilog tests/multi/multi0keep2const/multi0keep2const.v tests/multi/multi0keep/multi0keep.v --protocol tests/multi/multi0keep2const/multi0keep2const.prot --module multi0keep2const 2>/dev/null"
+
+[[tests]]
 name = "waveform.tests_multi_multi2const_multi2const.multi2const_waveform.ast"
 paths = [
   "../../tests/multi/multi2const/multi2const.tx",
@@ -467,6 +692,15 @@ paths = [
 expect_dir = "../../tests/multi/multi2const/expects"
 expect_name = "multi2const.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions tests/multi/multi2const/multi2const.tx --respect-forks --determinize --ascii-waveform --verilog tests/multi/multi2const/multi2const.v tests/multi/multi0/multi0.v --protocol tests/multi/multi2const/multi2const.prot --module multi2const 2>/dev/null"
+
+[[tests]]
+name = "waveform.tests_multi_multi2const_multi2const.multi2const_waveform.ts"
+paths = [
+  "../../tests/multi/multi2const/multi2const.tx",
+]
+expect_dir = "../../tests/multi/multi2const/expects"
+expect_name = "multi2const.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions tests/multi/multi2const/multi2const.tx --transition-system --ascii-waveform --verilog tests/multi/multi2const/multi2const.v tests/multi/multi0/multi0.v --protocol tests/multi/multi2const/multi2const.prot --module multi2const 2>/dev/null"
 
 [[tests]]
 name = "waveform.tests_multi_multi2multi_multi2multi.multi2multi_waveform.ast"
@@ -487,6 +721,15 @@ expect_name = "multi2multi.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions tests/multi/multi2multi/multi2multi.tx --respect-forks --determinize --ascii-waveform --verilog tests/multi/multi2multi/multi2multi.v tests/multi/multi0/multi0.v --protocol tests/multi/multi2multi/multi2multi.prot --module multi2multi 2>/dev/null"
 
 [[tests]]
+name = "waveform.tests_multi_multi2multi_multi2multi.multi2multi_waveform.ts"
+paths = [
+  "../../tests/multi/multi2multi/multi2multi.tx",
+]
+expect_dir = "../../tests/multi/multi2multi/expects"
+expect_name = "multi2multi.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions tests/multi/multi2multi/multi2multi.tx --transition-system --ascii-waveform --verilog tests/multi/multi2multi/multi2multi.v tests/multi/multi0/multi0.v --protocol tests/multi/multi2multi/multi2multi.prot --module multi2multi 2>/dev/null"
+
+[[tests]]
 name = "waveform.tests_multi_multi_data_multi_data.multi_data_waveform.ast"
 paths = [
   "../../tests/multi/multi_data/multi_data.tx",
@@ -505,6 +748,15 @@ expect_name = "multi_data.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions tests/multi/multi_data/multi_data.tx --respect-forks --determinize --ascii-waveform --verilog tests/multi/multi_data/multi_data.v --protocol tests/multi/multi_data/multi_data.prot 2>/dev/null"
 
 [[tests]]
+name = "waveform.tests_multi_multi_data_multi_data.multi_data_waveform.ts"
+paths = [
+  "../../tests/multi/multi_data/multi_data.tx",
+]
+expect_dir = "../../tests/multi/multi_data/expects"
+expect_name = "multi_data.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions tests/multi/multi_data/multi_data.tx --transition-system --ascii-waveform --verilog tests/multi/multi_data/multi_data.v --protocol tests/multi/multi_data/multi_data.prot 2>/dev/null"
+
+[[tests]]
 name = "waveform.tests_multipliers_mult_d2_both_threads_pass.both_threads_pass_waveform.ast"
 paths = [
   "../../tests/multipliers/mult_d2/both_threads_pass.tx",
@@ -521,3 +773,12 @@ paths = [
 expect_dir = "../../tests/multipliers/mult_d2/expects"
 expect_name = "both_threads_pass.waveform.expect"
 cmd = "cd ../.. && target/debug/graph-interp --transactions tests/multipliers/mult_d2/both_threads_pass.tx --respect-forks --determinize --ascii-waveform --verilog tests/multipliers/mult_d2/mult_d2.v --protocol tests/multipliers/mult_d2/mult_d2.prot 2>/dev/null"
+
+[[tests]]
+name = "waveform.tests_multipliers_mult_d2_both_threads_pass.both_threads_pass_waveform.ts"
+paths = [
+  "../../tests/multipliers/mult_d2/both_threads_pass.tx",
+]
+expect_dir = "../../tests/multipliers/mult_d2/expects"
+expect_name = "both_threads_pass.waveform.expect"
+cmd = "cd ../.. && target/debug/graph-interp --transactions tests/multipliers/mult_d2/both_threads_pass.tx --transition-system --ascii-waveform --verilog tests/multipliers/mult_d2/mult_d2.v --protocol tests/multipliers/mult_d2/mult_d2.prot 2>/dev/null"

--- a/scripts/generate_runt_configs.py
+++ b/scripts/generate_runt_configs.py
@@ -216,9 +216,19 @@ def waveform_runt_command(case: dict) -> list[tuple[str, str]]:
     ]
     _tx_tail(graph_cmd, case, with_max_steps=False)
 
+    ts_cmd = [
+        *binary_prefix("graph-interp"),
+        "--transactions",
+        case["path"],
+        "--transition-system",
+        "--ascii-waveform",
+    ]
+    _tx_tail(ts_cmd, case, with_max_steps=False)
+
     return [
         ("ast", repo_root_command(ast_cmd, stderr="discard")),
         ("graph", repo_root_command(graph_cmd, stderr="discard")),
+        ("ts", repo_root_command(ts_cmd, stderr="discard")),
     ]
 
 


### PR DESCRIPTION
All the interesting stuff is in `backends/transition_system.rs`. It is essentially as we discussed yesterday.
- Implemented the thing where we have certain expressions that are true iff an input is DontCare. that way, we can update the waveform based on that. 
- assertions go to a ExternalAssertBadState. if we end up in a situation where an InternalAssert triggers, or no outgoing transitions trigger but we're not at the Done state, or none of the assignments trigger, we move to the InternalAssertBadState. 

In `graph_interp/main.rs`, we have a new flow that runs with `--transition-system` 
 
All waveform tests are passing, but I have not added the logic to handle differentially testing failing tests yet. This will require changes potentially in the graph interpreter, so it is best to leave as a follow-up PR.