### PR TITLE
bi: towards ethmac support

### DIFF
--- a/bi/src/bi.rs
+++ b/bi/src/bi.rs
@@ -786,7 +786,18 @@ impl Thread {
             // only the final assignment to a pin matters
             if !pins_assigned.contains(&pin) {
                 pins_assigned.insert(pin);
-                let pin_expr = ti.pin_exprs[&pin];
+                let pin_expr = *ti.pin_exprs.get(&pin).unwrap_or_else(|| {
+                    panic!(
+                        "pin `{}` ({:?}) not found\navailable: {}",
+                        ti.sym[pin].full_name(&ti.sym),
+                        pin,
+                        ti.pin_exprs
+                            .keys()
+                            .map(|p| ti.sym[p].full_name(&ti.sym).to_string())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )
+                });
                 if let Some(fail) = self.exec_equality(get_value, ti, stmt, pin_expr, expr) {
                     self.failures.push(fail);
                 } else if !matches!(ti.proto[expr], Expr::DontCare) {

--- a/bi/src/main.rs
+++ b/bi/src/main.rs
@@ -86,10 +86,18 @@ struct Cli {
     display_hex: bool,
 }
 
-fn get_clock(modules: &[Module], cli_sample_posedge: Option<String>) -> Option<String> {
-    let mut clocks: Vec<String> = modules
+fn get_clock(
+    modules: &[Module],
+    instances: &[Instance],
+    cli_sample_posedge: Option<String>,
+) -> Option<String> {
+    let mut used_modules: Vec<_> = instances.iter().map(|i| i.module_id).collect();
+    used_modules.sort();
+    used_modules.dedup();
+
+    let mut clocks: Vec<String> = used_modules
         .iter()
-        .flat_map(|m| match &m.clock {
+        .flat_map(|&m_id| match &modules[m_id].clock {
             Clock::None => None,
             Clock::Posedge(name) => Some(name.to_string()),
         })
@@ -129,7 +137,6 @@ fn main() {
     let skip_static_step_fork_checks = false;
     let mut d = DiagnosticHandler::new(cli.color, false, show_warnings, false);
     let (st, modules) = frontend(&cli.protocol, &mut d, skip_static_step_fork_checks).unwrap();
-    let posedge_clock = get_clock(&modules, cli.sample_posedge);
 
     // try to find instances that we care about
     if cli.instances.is_empty() {
@@ -143,6 +150,8 @@ fn main() {
         .iter()
         .map(|arg| parse_instance(&modules, arg))
         .collect();
+
+    let posedge_clock = get_clock(&modules, &instances, cli.sample_posedge);
 
     let bi_protos: Vec<Vec<_>> = instances
         .iter()

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -32,7 +32,10 @@ enum Cmds {
     /// Print out all the constructs used in each protocol
     Constructs,
     /// Prints out the protocols after the frontend processing
-    Show,
+    Show {
+        #[arg(long, help = "only include these modules")]
+        include: Vec<String>,
+    },
     Verilog {
         verilog_tb: String,
         #[arg(long)]
@@ -180,8 +183,17 @@ fn run_verilog_tb(
         .unwrap();
 }
 
-fn show(st: &SymbolTable, modules: &[Module]) {
-    serialize_modules(&mut std::io::stdout(), st, modules).unwrap();
+fn show(st: &SymbolTable, modules: &[Module], include: &[String]) {
+    if include.is_empty() {
+        serialize_modules(&mut std::io::stdout(), st, modules).unwrap();
+    } else {
+        let modules: Vec<_> = modules
+            .iter()
+            .filter(|m| include.contains(&m.name))
+            .cloned()
+            .collect();
+        serialize_modules(&mut std::io::stdout(), st, &modules).unwrap();
+    }
 }
 
 fn main() {
@@ -202,8 +214,8 @@ fn main() {
                 }
             }
         }
-        Some(Cmds::Show) => {
-            show(&st, &modules);
+        Some(Cmds::Show { include }) => {
+            show(&st, &modules, &include);
         }
         Some(Cmds::Verilog {
             verilog_tb,

--- a/examples/wishbone/antmicro_litex.prot
+++ b/examples/wishbone/antmicro_litex.prot
@@ -16,4 +16,6 @@ module LitexWishbone : Wishbone {
   in wishbone_cti : u3 = Wishbone.CTI,
   in wishbone_bte : u2 = Wishbone.BTE,
   out wishbone_err : u1 = Wishbone.ERR,
+  // RTY is not used
+  const Wishbone.RTY = 1'b0,
 }

--- a/examples/wishbone/ethmac.prot
+++ b/examples/wishbone/ethmac.prot
@@ -45,7 +45,7 @@ module Tb_ethernetWb_masterWbm_low_level : Wishbone {
   out ACK_I : u1 = Wishbone.ACK,
   in SEL_O : u4 = Wishbone.SEL,
   out ERR_I : u1 = Wishbone.ERR,
-  out RTY_I : u1 = Wishbone.RTY,
+  // out RTY_I : u1 = Wishbone.RTY,
 }
 
 // --instances tb_ethernet.wb_master:Tb_ethernetWb_master --wave wishbone/ethmac/ethmac.fst
@@ -61,7 +61,7 @@ module Tb_ethernetWb_master : Wishbone {
   out ACK_I : u1 = Wishbone.ACK,
   in SEL_O : u4 = Wishbone.SEL,
   out ERR_I : u1 = Wishbone.ERR,
-  out RTY_I : u1 = Wishbone.RTY,
+  // out RTY_I : u1 = Wishbone.RTY,
 }
 
 // --instances tb_ethernet.wb_slave:Tb_ethernetWb_slave --wave wishbone/ethmac/ethmac.fst
@@ -77,7 +77,7 @@ module Tb_ethernetWb_slave : Wishbone {
   out ACK_O : u1 = Wishbone.ACK,
   in SEL_I : u4 = Wishbone.SEL,
   out ERR_O : u1 = Wishbone.ERR,
-  out RTY_O : u1 = Wishbone.RTY,
+  // out RTY_O : u1 = Wishbone.RTY,
 }
 
 // --instances tb_ethernet:Tb_ethernetEthSlWb --wave wishbone/ethmac/ethmac.fst

--- a/examples/wishbone/ethmac.prot
+++ b/examples/wishbone/ethmac.prot
@@ -1,0 +1,112 @@
+// --instances tb_ethernet.eth_top.wishbone:Tb_ethernetEth_topWishboneMWb --wave wishbone/ethmac/ethmac.fst
+module Tb_ethernetEth_topWishboneMWb : Wishbone {
+  in WB_CLK_I : clock @posedge,
+  in Reset : u1 = Wishbone.RST,
+  in m_wb_adr_o : u30 = Wishbone.ADR[31:2] with Wishbone.ADR[1:0] == 2'd0,
+  out m_wb_dat_i : u32 = Wishbone.DAT_I,
+  in m_wb_dat_o : u32 = Wishbone.DAT_O,
+  in m_wb_we_o : u1 = Wishbone.WE,
+  in m_wb_stb_o : u1 = Wishbone.STB,
+  in m_wb_cyc_o : u1 = Wishbone.CYC,
+  out m_wb_ack_i : u1 = Wishbone.ACK,
+  in m_wb_sel_o : u4 = Wishbone.SEL,
+  out m_wb_err_i : u1 = Wishbone.ERR,
+  in m_wb_cti_o : u3 = Wishbone.CTI,
+  in m_wb_bte_o : u2 = Wishbone.BTE,
+}
+
+// --instances tb_ethernet.eth_top:Tb_ethernetEth_topMWb --wave wishbone/ethmac/ethmac.fst
+module Tb_ethernetEth_topMWb : Wishbone {
+  in wb_clk_i : clock @posedge,
+  in wb_rst_i : u1 = Wishbone.RST,
+  in m_wb_adr_o : u32 = Wishbone.ADR,
+  out m_wb_dat_i : u32 = Wishbone.DAT_I,
+  in m_wb_dat_o : u32 = Wishbone.DAT_O,
+  in m_wb_we_o : u1 = Wishbone.WE,
+  in m_wb_stb_o : u1 = Wishbone.STB,
+  in m_wb_cyc_o : u1 = Wishbone.CYC,
+  out m_wb_ack_i : u1 = Wishbone.ACK,
+  in m_wb_sel_o : u4 = Wishbone.SEL,
+  out m_wb_err_i : u1 = Wishbone.ERR,
+  in m_wb_cti_o : u3 = Wishbone.CTI,
+  in m_wb_bte_o : u2 = Wishbone.BTE,
+}
+
+// --instances tb_ethernet.wb_master.wbm_low_level:Tb_ethernetWb_masterWbm_low_level --wave wishbone/ethmac/ethmac.fst
+module Tb_ethernetWb_masterWbm_low_level : Wishbone {
+  in CLK_I : clock @posedge,
+  in RST_I : u1 = Wishbone.RST,
+  in ADR_O : u32 = Wishbone.ADR,
+  out DAT_I : u32 = Wishbone.DAT_I,
+  in DAT_O : u32 = Wishbone.DAT_O,
+  in WE_O : u1 = Wishbone.WE,
+  in STB_O : u1 = Wishbone.STB,
+  in CYC_O : u1 = Wishbone.CYC,
+  out ACK_I : u1 = Wishbone.ACK,
+  in SEL_O : u4 = Wishbone.SEL,
+  out ERR_I : u1 = Wishbone.ERR,
+  out RTY_I : u1 = Wishbone.RTY,
+}
+
+// --instances tb_ethernet.wb_master:Tb_ethernetWb_master --wave wishbone/ethmac/ethmac.fst
+module Tb_ethernetWb_master : Wishbone {
+  in CLK_I : clock @posedge,
+  in RST_I : u1 = Wishbone.RST,
+  in ADR_O : u32 = Wishbone.ADR,
+  out DAT_I : u32 = Wishbone.DAT_I,
+  in DAT_O : u32 = Wishbone.DAT_O,
+  in WE_O : u1 = Wishbone.WE,
+  in STB_O : u1 = Wishbone.STB,
+  in CYC_O : u1 = Wishbone.CYC,
+  out ACK_I : u1 = Wishbone.ACK,
+  in SEL_O : u4 = Wishbone.SEL,
+  out ERR_I : u1 = Wishbone.ERR,
+  out RTY_I : u1 = Wishbone.RTY,
+}
+
+// --instances tb_ethernet.wb_slave:Tb_ethernetWb_slave --wave wishbone/ethmac/ethmac.fst
+module Tb_ethernetWb_slave : Wishbone {
+  in CLK_I : clock @posedge,
+  in RST_I : u1 = Wishbone.RST,
+  in ADR_I : u32 = Wishbone.ADR,
+  out DAT_I : u32 = Wishbone.DAT_I,
+  in DAT_O : u32 = Wishbone.DAT_O,
+  in WE_I : u1 = Wishbone.WE,
+  in STB_I : u1 = Wishbone.STB,
+  in CYC_I : u1 = Wishbone.CYC,
+  out ACK_O : u1 = Wishbone.ACK,
+  in SEL_I : u4 = Wishbone.SEL,
+  out ERR_O : u1 = Wishbone.ERR,
+  out RTY_O : u1 = Wishbone.RTY,
+}
+
+// --instances tb_ethernet:Tb_ethernetEthSlWb --wave wishbone/ethmac/ethmac.fst
+module Tb_ethernetEthSlWb : Wishbone {
+  in wb_clk : clock @posedge,
+  in wb_rst : u1 = Wishbone.RST,
+  in eth_sl_wb_adr_i : u32 = Wishbone.ADR,
+  out eth_sl_wb_dat_i : u32 = Wishbone.DAT_I,
+  in eth_sl_wb_dat_o : u32 = Wishbone.DAT_O,
+  in eth_sl_wb_we_i : u1 = Wishbone.WE,
+  in eth_sl_wb_stb_i : u1 = Wishbone.STB,
+  in eth_sl_wb_cyc_i : u1 = Wishbone.CYC,
+  out eth_sl_wb_ack_o : u1 = Wishbone.ACK,
+  in eth_sl_wb_sel_i : u4 = Wishbone.SEL,
+  out eth_sl_wb_err_o : u1 = Wishbone.ERR,
+}
+
+// --instances tb_ethernet:Tb_ethernetEthMaWb --wave wishbone/ethmac/ethmac.fst
+module Tb_ethernetEthMaWb : Wishbone {
+  in wb_clk : clock @posedge,
+  in wb_rst : u1 = Wishbone.RST,
+  in eth_ma_wb_adr_o : u32 = Wishbone.ADR,
+  out eth_ma_wb_dat_i : u32 = Wishbone.DAT_I,
+  in eth_ma_wb_dat_o : u32 = Wishbone.DAT_O,
+  in eth_ma_wb_we_o : u1 = Wishbone.WE,
+  in eth_ma_wb_stb_o : u1 = Wishbone.STB,
+  in eth_ma_wb_cyc_o : u1 = Wishbone.CYC,
+  out eth_ma_wb_ack_i : u1 = Wishbone.ACK,
+  in eth_ma_wb_sel_o : u4 = Wishbone.SEL,
+  out eth_ma_wb_err_i : u1 = Wishbone.ERR,
+}
+

--- a/examples/wishbone/ethmac.prot
+++ b/examples/wishbone/ethmac.prot
@@ -13,6 +13,7 @@ module Tb_ethernetEth_topWishboneMWb : Wishbone {
   out m_wb_err_i : u1 = Wishbone.ERR,
   in m_wb_cti_o : u3 = Wishbone.CTI,
   in m_wb_bte_o : u2 = Wishbone.BTE,
+  const Wishbone.RTY = 1'b0,
 }
 
 // --instances tb_ethernet.eth_top:Tb_ethernetEth_topMWb --wave wishbone/ethmac/ethmac.fst
@@ -45,7 +46,7 @@ module Tb_ethernetWb_masterWbm_low_level : Wishbone {
   out ACK_I : u1 = Wishbone.ACK,
   in SEL_O : u4 = Wishbone.SEL,
   out ERR_I : u1 = Wishbone.ERR,
-  // out RTY_I : u1 = Wishbone.RTY,
+  out RTY_I : u1 = Wishbone.RTY,
 }
 
 // --instances tb_ethernet.wb_master:Tb_ethernetWb_master --wave wishbone/ethmac/ethmac.fst
@@ -61,7 +62,7 @@ module Tb_ethernetWb_master : Wishbone {
   out ACK_I : u1 = Wishbone.ACK,
   in SEL_O : u4 = Wishbone.SEL,
   out ERR_I : u1 = Wishbone.ERR,
-  // out RTY_I : u1 = Wishbone.RTY,
+  out RTY_I : u1 = Wishbone.RTY,
 }
 
 // --instances tb_ethernet.wb_slave:Tb_ethernetWb_slave --wave wishbone/ethmac/ethmac.fst
@@ -77,7 +78,7 @@ module Tb_ethernetWb_slave : Wishbone {
   out ACK_O : u1 = Wishbone.ACK,
   in SEL_I : u4 = Wishbone.SEL,
   out ERR_O : u1 = Wishbone.ERR,
-  // out RTY_O : u1 = Wishbone.RTY,
+  out RTY_O : u1 = Wishbone.RTY,
 }
 
 // --instances tb_ethernet:Tb_ethernetEthSlWb --wave wishbone/ethmac/ethmac.fst

--- a/examples/wishbone/ethmac.prot
+++ b/examples/wishbone/ethmac.prot
@@ -31,6 +31,7 @@ module Tb_ethernetEth_topMWb : Wishbone {
   out m_wb_err_i : u1 = Wishbone.ERR,
   in m_wb_cti_o : u3 = Wishbone.CTI,
   in m_wb_bte_o : u2 = Wishbone.BTE,
+  const Wishbone.RTY = 1'b0, // no retry
 }
 
 // --instances tb_ethernet.wb_master.wbm_low_level:Tb_ethernetWb_masterWbm_low_level --wave wishbone/ethmac/ethmac.fst
@@ -47,6 +48,9 @@ module Tb_ethernetWb_masterWbm_low_level : Wishbone {
   in SEL_O : u4 = Wishbone.SEL,
   out ERR_I : u1 = Wishbone.ERR,
   out RTY_I : u1 = Wishbone.RTY,
+  // no bursts
+  const Wishbone.BTE = 2'd0,
+  const Wishbone.CTI = 3'd0,
 }
 
 // --instances tb_ethernet.wb_master:Tb_ethernetWb_master --wave wishbone/ethmac/ethmac.fst
@@ -63,6 +67,9 @@ module Tb_ethernetWb_master : Wishbone {
   in SEL_O : u4 = Wishbone.SEL,
   out ERR_I : u1 = Wishbone.ERR,
   out RTY_I : u1 = Wishbone.RTY,
+  // no bursts
+  const Wishbone.BTE = 2'd0,
+  const Wishbone.CTI = 3'd0,
 }
 
 // --instances tb_ethernet.wb_slave:Tb_ethernetWb_slave --wave wishbone/ethmac/ethmac.fst
@@ -79,6 +86,9 @@ module Tb_ethernetWb_slave : Wishbone {
   in SEL_I : u4 = Wishbone.SEL,
   out ERR_O : u1 = Wishbone.ERR,
   out RTY_O : u1 = Wishbone.RTY,
+  // no bursts
+  const Wishbone.BTE = 2'd0,
+  const Wishbone.CTI = 3'd0,
 }
 
 // --instances tb_ethernet:Tb_ethernetEthSlWb --wave wishbone/ethmac/ethmac.fst
@@ -94,6 +104,10 @@ module Tb_ethernetEthSlWb : Wishbone {
   out eth_sl_wb_ack_o : u1 = Wishbone.ACK,
   in eth_sl_wb_sel_i : u4 = Wishbone.SEL,
   out eth_sl_wb_err_o : u1 = Wishbone.ERR,
+  // no bursts
+  const Wishbone.BTE = 2'd0,
+  const Wishbone.CTI = 3'd0,
+  const Wishbone.RTY = 1'b0, // no retry
 }
 
 // --instances tb_ethernet:Tb_ethernetEthMaWb --wave wishbone/ethmac/ethmac.fst
@@ -109,5 +123,9 @@ module Tb_ethernetEthMaWb : Wishbone {
   out eth_ma_wb_ack_i : u1 = Wishbone.ACK,
   in eth_ma_wb_sel_o : u4 = Wishbone.SEL,
   out eth_ma_wb_err_i : u1 = Wishbone.ERR,
+  // no bursts
+  const Wishbone.BTE = 2'd0,
+  const Wishbone.CTI = 3'd0,
+  const Wishbone.RTY = 1'b0, // no retry
 }
 

--- a/examples/wishbone/expects/test_sram_incrementing_16_0_1.bi.expect
+++ b/examples/wishbone/expects/test_sram_incrementing_16_0_1.bi.expect
@@ -5,9 +5,9 @@ trace {
     reset(); [4]
 }
 error: [read_burst_increment_wrap_4@41] executing step 5 of the transaction: 04000004 != 04000000
-    ┌─ examples/wishbone/wishbone.prot:408:9
+    ┌─ examples/wishbone/wishbone.prot:409:9
     │
-408 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
+409 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_4@41] executing step 5 of the transaction: 04000004 != 04000000
 
 
@@ -18,15 +18,15 @@ trace {
     reset(); [4]
 }
 error: [read_burst_increment_wrap_4@41L] executing step 5 of the transaction: 2 != 7
-    ┌─ examples/wishbone/wishbone.prot:412:13
+    ┌─ examples/wishbone/wishbone.prot:413:13
     │
-412 │             self.CTI := 3'b111;
+413 │             self.CTI := 3'b111;
     │             ^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_4@41L] executing step 5 of the transaction: 2 != 7
 
 error: [read_burst_increment_wrap_4@41L] executing step 5 of the transaction: 04000004 != 04000000
-    ┌─ examples/wishbone/wishbone.prot:408:9
+    ┌─ examples/wishbone/wishbone.prot:409:9
     │
-408 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
+409 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_4@41L] executing step 5 of the transaction: 04000004 != 04000000
 
 ---CODE---

--- a/examples/wishbone/expects/test_sram_incrementing_16_0_2.bi.expect
+++ b/examples/wishbone/expects/test_sram_incrementing_16_0_2.bi.expect
@@ -5,9 +5,9 @@ trace {
     reset(); [4]
 }
 error: [read_burst_increment_wrap_8@41] executing step 9 of the transaction: 04000008 != 04000000
-    ┌─ examples/wishbone/wishbone.prot:486:9
+    ┌─ examples/wishbone/wishbone.prot:487:9
     │
-486 │         self.ADR := start_addr[31:5] ## (start_addr[4:2] + iter_count::<u3>()) ## start_addr[1:0];
+487 │         self.ADR := start_addr[31:5] ## (start_addr[4:2] + iter_count::<u3>()) ## start_addr[1:0];
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_8@41] executing step 9 of the transaction: 04000008 != 04000000
 
 
@@ -18,15 +18,15 @@ trace {
     reset(); [4]
 }
 error: [read_burst_increment_wrap_8@41L] executing step 9 of the transaction: 2 != 7
-    ┌─ examples/wishbone/wishbone.prot:490:13
+    ┌─ examples/wishbone/wishbone.prot:491:13
     │
-490 │             self.CTI := 3'b111;
+491 │             self.CTI := 3'b111;
     │             ^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_8@41L] executing step 9 of the transaction: 2 != 7
 
 error: [read_burst_increment_wrap_8@41L] executing step 9 of the transaction: 04000008 != 04000000
-    ┌─ examples/wishbone/wishbone.prot:486:9
+    ┌─ examples/wishbone/wishbone.prot:487:9
     │
-486 │         self.ADR := start_addr[31:5] ## (start_addr[4:2] + iter_count::<u3>()) ## start_addr[1:0];
+487 │         self.ADR := start_addr[31:5] ## (start_addr[4:2] + iter_count::<u3>()) ## start_addr[1:0];
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_8@41L] executing step 9 of the transaction: 04000008 != 04000000
 
 ---CODE---

--- a/examples/wishbone/expects/test_sram_incrementing_16_12_1.bi.expect
+++ b/examples/wishbone/expects/test_sram_incrementing_16_12_1.bi.expect
@@ -5,9 +5,9 @@ trace {
     reset(); [4]
 }
 error: [read_burst_increment_wrap_4@41] executing step 5 of the transaction: 04000007 != 04000003
-    ┌─ examples/wishbone/wishbone.prot:408:9
+    ┌─ examples/wishbone/wishbone.prot:409:9
     │
-408 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
+409 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_4@41] executing step 5 of the transaction: 04000007 != 04000003
 
 
@@ -18,15 +18,15 @@ trace {
     reset(); [4]
 }
 error: [read_burst_increment_wrap_4@41L] executing step 5 of the transaction: 2 != 7
-    ┌─ examples/wishbone/wishbone.prot:412:13
+    ┌─ examples/wishbone/wishbone.prot:413:13
     │
-412 │             self.CTI := 3'b111;
+413 │             self.CTI := 3'b111;
     │             ^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_4@41L] executing step 5 of the transaction: 2 != 7
 
 error: [read_burst_increment_wrap_4@41L] executing step 5 of the transaction: 04000007 != 04000003
-    ┌─ examples/wishbone/wishbone.prot:408:9
+    ┌─ examples/wishbone/wishbone.prot:409:9
     │
-408 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
+409 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_4@41L] executing step 5 of the transaction: 04000007 != 04000003
 
 ---CODE---

--- a/examples/wishbone/expects/test_sram_incrementing_16_12_2.bi.expect
+++ b/examples/wishbone/expects/test_sram_incrementing_16_12_2.bi.expect
@@ -5,9 +5,9 @@ trace {
     reset(); [4]
 }
 error: [read_burst_increment_wrap_8@41] executing step 9 of the transaction: 0400000b != 04000003
-    ┌─ examples/wishbone/wishbone.prot:486:9
+    ┌─ examples/wishbone/wishbone.prot:487:9
     │
-486 │         self.ADR := start_addr[31:5] ## (start_addr[4:2] + iter_count::<u3>()) ## start_addr[1:0];
+487 │         self.ADR := start_addr[31:5] ## (start_addr[4:2] + iter_count::<u3>()) ## start_addr[1:0];
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_8@41] executing step 9 of the transaction: 0400000b != 04000003
 
 
@@ -18,15 +18,15 @@ trace {
     reset(); [4]
 }
 error: [read_burst_increment_wrap_8@41L] executing step 9 of the transaction: 2 != 7
-    ┌─ examples/wishbone/wishbone.prot:490:13
+    ┌─ examples/wishbone/wishbone.prot:491:13
     │
-490 │             self.CTI := 3'b111;
+491 │             self.CTI := 3'b111;
     │             ^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_8@41L] executing step 9 of the transaction: 2 != 7
 
 error: [read_burst_increment_wrap_8@41L] executing step 9 of the transaction: 0400000b != 04000003
-    ┌─ examples/wishbone/wishbone.prot:486:9
+    ┌─ examples/wishbone/wishbone.prot:487:9
     │
-486 │         self.ADR := start_addr[31:5] ## (start_addr[4:2] + iter_count::<u3>()) ## start_addr[1:0];
+487 │         self.ADR := start_addr[31:5] ## (start_addr[4:2] + iter_count::<u3>()) ## start_addr[1:0];
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_8@41L] executing step 9 of the transaction: 0400000b != 04000003
 
 ---CODE---

--- a/examples/wishbone/expects/test_sram_incrementing_16_4_1.bi.expect
+++ b/examples/wishbone/expects/test_sram_incrementing_16_4_1.bi.expect
@@ -5,9 +5,9 @@ trace {
     reset(); [4]
 }
 error: [read_burst_increment_wrap_4@41] executing step 5 of the transaction: 04000005 != 04000001
-    ┌─ examples/wishbone/wishbone.prot:408:9
+    ┌─ examples/wishbone/wishbone.prot:409:9
     │
-408 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
+409 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_4@41] executing step 5 of the transaction: 04000005 != 04000001
 
 
@@ -18,15 +18,15 @@ trace {
     reset(); [4]
 }
 error: [read_burst_increment_wrap_4@41L] executing step 5 of the transaction: 2 != 7
-    ┌─ examples/wishbone/wishbone.prot:412:13
+    ┌─ examples/wishbone/wishbone.prot:413:13
     │
-412 │             self.CTI := 3'b111;
+413 │             self.CTI := 3'b111;
     │             ^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_4@41L] executing step 5 of the transaction: 2 != 7
 
 error: [read_burst_increment_wrap_4@41L] executing step 5 of the transaction: 04000005 != 04000001
-    ┌─ examples/wishbone/wishbone.prot:408:9
+    ┌─ examples/wishbone/wishbone.prot:409:9
     │
-408 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
+409 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_4@41L] executing step 5 of the transaction: 04000005 != 04000001
 
 ---CODE---

--- a/examples/wishbone/expects/test_sram_incrementing_16_4_2.bi.expect
+++ b/examples/wishbone/expects/test_sram_incrementing_16_4_2.bi.expect
@@ -5,9 +5,9 @@ trace {
     reset(); [4]
 }
 error: [read_burst_increment_wrap_8@41] executing step 9 of the transaction: 04000009 != 04000001
-    ┌─ examples/wishbone/wishbone.prot:486:9
+    ┌─ examples/wishbone/wishbone.prot:487:9
     │
-486 │         self.ADR := start_addr[31:5] ## (start_addr[4:2] + iter_count::<u3>()) ## start_addr[1:0];
+487 │         self.ADR := start_addr[31:5] ## (start_addr[4:2] + iter_count::<u3>()) ## start_addr[1:0];
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_8@41] executing step 9 of the transaction: 04000009 != 04000001
 
 
@@ -18,15 +18,15 @@ trace {
     reset(); [4]
 }
 error: [read_burst_increment_wrap_8@41L] executing step 9 of the transaction: 2 != 7
-    ┌─ examples/wishbone/wishbone.prot:490:13
+    ┌─ examples/wishbone/wishbone.prot:491:13
     │
-490 │             self.CTI := 3'b111;
+491 │             self.CTI := 3'b111;
     │             ^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_8@41L] executing step 9 of the transaction: 2 != 7
 
 error: [read_burst_increment_wrap_8@41L] executing step 9 of the transaction: 04000009 != 04000001
-    ┌─ examples/wishbone/wishbone.prot:486:9
+    ┌─ examples/wishbone/wishbone.prot:487:9
     │
-486 │         self.ADR := start_addr[31:5] ## (start_addr[4:2] + iter_count::<u3>()) ## start_addr[1:0];
+487 │         self.ADR := start_addr[31:5] ## (start_addr[4:2] + iter_count::<u3>()) ## start_addr[1:0];
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_8@41L] executing step 9 of the transaction: 04000009 != 04000001
 
 ---CODE---

--- a/examples/wishbone/expects/test_sram_incrementing_16_8_1.bi.expect
+++ b/examples/wishbone/expects/test_sram_incrementing_16_8_1.bi.expect
@@ -5,9 +5,9 @@ trace {
     reset(); [4]
 }
 error: [read_burst_increment_wrap_4@41] executing step 5 of the transaction: 04000006 != 04000002
-    ┌─ examples/wishbone/wishbone.prot:408:9
+    ┌─ examples/wishbone/wishbone.prot:409:9
     │
-408 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
+409 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_4@41] executing step 5 of the transaction: 04000006 != 04000002
 
 
@@ -18,15 +18,15 @@ trace {
     reset(); [4]
 }
 error: [read_burst_increment_wrap_4@41L] executing step 5 of the transaction: 2 != 7
-    ┌─ examples/wishbone/wishbone.prot:412:13
+    ┌─ examples/wishbone/wishbone.prot:413:13
     │
-412 │             self.CTI := 3'b111;
+413 │             self.CTI := 3'b111;
     │             ^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_4@41L] executing step 5 of the transaction: 2 != 7
 
 error: [read_burst_increment_wrap_4@41L] executing step 5 of the transaction: 04000006 != 04000002
-    ┌─ examples/wishbone/wishbone.prot:408:9
+    ┌─ examples/wishbone/wishbone.prot:409:9
     │
-408 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
+409 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_4@41L] executing step 5 of the transaction: 04000006 != 04000002
 
 ---CODE---

--- a/examples/wishbone/expects/test_sram_incrementing_16_8_2.bi.expect
+++ b/examples/wishbone/expects/test_sram_incrementing_16_8_2.bi.expect
@@ -5,9 +5,9 @@ trace {
     reset(); [4]
 }
 error: [read_burst_increment_wrap_8@41] executing step 9 of the transaction: 0400000a != 04000002
-    ┌─ examples/wishbone/wishbone.prot:486:9
+    ┌─ examples/wishbone/wishbone.prot:487:9
     │
-486 │         self.ADR := start_addr[31:5] ## (start_addr[4:2] + iter_count::<u3>()) ## start_addr[1:0];
+487 │         self.ADR := start_addr[31:5] ## (start_addr[4:2] + iter_count::<u3>()) ## start_addr[1:0];
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_8@41] executing step 9 of the transaction: 0400000a != 04000002
 
 
@@ -18,15 +18,15 @@ trace {
     reset(); [4]
 }
 error: [read_burst_increment_wrap_8@41L] executing step 9 of the transaction: 2 != 7
-    ┌─ examples/wishbone/wishbone.prot:490:13
+    ┌─ examples/wishbone/wishbone.prot:491:13
     │
-490 │             self.CTI := 3'b111;
+491 │             self.CTI := 3'b111;
     │             ^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_8@41L] executing step 9 of the transaction: 2 != 7
 
 error: [read_burst_increment_wrap_8@41L] executing step 9 of the transaction: 0400000a != 04000002
-    ┌─ examples/wishbone/wishbone.prot:486:9
+    ┌─ examples/wishbone/wishbone.prot:487:9
     │
-486 │         self.ADR := start_addr[31:5] ## (start_addr[4:2] + iter_count::<u3>()) ## start_addr[1:0];
+487 │         self.ADR := start_addr[31:5] ## (start_addr[4:2] + iter_count::<u3>()) ## start_addr[1:0];
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_8@41L] executing step 9 of the transaction: 0400000a != 04000002
 
 ---CODE---

--- a/examples/wishbone/expects/test_sram_incrementing_8_0_1.bi.expect
+++ b/examples/wishbone/expects/test_sram_incrementing_8_0_1.bi.expect
@@ -5,9 +5,9 @@ trace {
     reset(); [4]
 }
 error: [read_burst_increment_wrap_4@25] executing step 5 of the transaction: 04000004 != 04000000
-    ┌─ examples/wishbone/wishbone.prot:408:9
+    ┌─ examples/wishbone/wishbone.prot:409:9
     │
-408 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
+409 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_4@25] executing step 5 of the transaction: 04000004 != 04000000
 
 
@@ -18,15 +18,15 @@ trace {
     reset(); [4]
 }
 error: [read_burst_increment_wrap_4@25L] executing step 5 of the transaction: 2 != 7
-    ┌─ examples/wishbone/wishbone.prot:412:13
+    ┌─ examples/wishbone/wishbone.prot:413:13
     │
-412 │             self.CTI := 3'b111;
+413 │             self.CTI := 3'b111;
     │             ^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_4@25L] executing step 5 of the transaction: 2 != 7
 
 error: [read_burst_increment_wrap_4@25L] executing step 5 of the transaction: 04000004 != 04000000
-    ┌─ examples/wishbone/wishbone.prot:408:9
+    ┌─ examples/wishbone/wishbone.prot:409:9
     │
-408 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
+409 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_4@25L] executing step 5 of the transaction: 04000004 != 04000000
 
 ---CODE---

--- a/examples/wishbone/expects/test_sram_incrementing_8_12_1.bi.expect
+++ b/examples/wishbone/expects/test_sram_incrementing_8_12_1.bi.expect
@@ -5,9 +5,9 @@ trace {
     reset(); [4]
 }
 error: [read_burst_increment_wrap_4@25] executing step 5 of the transaction: 04000007 != 04000003
-    ┌─ examples/wishbone/wishbone.prot:408:9
+    ┌─ examples/wishbone/wishbone.prot:409:9
     │
-408 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
+409 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_4@25] executing step 5 of the transaction: 04000007 != 04000003
 
 
@@ -18,15 +18,15 @@ trace {
     reset(); [4]
 }
 error: [read_burst_increment_wrap_4@25L] executing step 5 of the transaction: 2 != 7
-    ┌─ examples/wishbone/wishbone.prot:412:13
+    ┌─ examples/wishbone/wishbone.prot:413:13
     │
-412 │             self.CTI := 3'b111;
+413 │             self.CTI := 3'b111;
     │             ^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_4@25L] executing step 5 of the transaction: 2 != 7
 
 error: [read_burst_increment_wrap_4@25L] executing step 5 of the transaction: 04000007 != 04000003
-    ┌─ examples/wishbone/wishbone.prot:408:9
+    ┌─ examples/wishbone/wishbone.prot:409:9
     │
-408 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
+409 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_4@25L] executing step 5 of the transaction: 04000007 != 04000003
 
 ---CODE---

--- a/examples/wishbone/expects/test_sram_incrementing_8_4_1.bi.expect
+++ b/examples/wishbone/expects/test_sram_incrementing_8_4_1.bi.expect
@@ -5,9 +5,9 @@ trace {
     reset(); [4]
 }
 error: [read_burst_increment_wrap_4@25] executing step 5 of the transaction: 04000005 != 04000001
-    ┌─ examples/wishbone/wishbone.prot:408:9
+    ┌─ examples/wishbone/wishbone.prot:409:9
     │
-408 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
+409 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_4@25] executing step 5 of the transaction: 04000005 != 04000001
 
 
@@ -18,15 +18,15 @@ trace {
     reset(); [4]
 }
 error: [read_burst_increment_wrap_4@25L] executing step 5 of the transaction: 2 != 7
-    ┌─ examples/wishbone/wishbone.prot:412:13
+    ┌─ examples/wishbone/wishbone.prot:413:13
     │
-412 │             self.CTI := 3'b111;
+413 │             self.CTI := 3'b111;
     │             ^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_4@25L] executing step 5 of the transaction: 2 != 7
 
 error: [read_burst_increment_wrap_4@25L] executing step 5 of the transaction: 04000005 != 04000001
-    ┌─ examples/wishbone/wishbone.prot:408:9
+    ┌─ examples/wishbone/wishbone.prot:409:9
     │
-408 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
+409 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_4@25L] executing step 5 of the transaction: 04000005 != 04000001
 
 ---CODE---

--- a/examples/wishbone/expects/test_sram_incrementing_8_8_1.bi.expect
+++ b/examples/wishbone/expects/test_sram_incrementing_8_8_1.bi.expect
@@ -5,9 +5,9 @@ trace {
     reset(); [4]
 }
 error: [read_burst_increment_wrap_4@25] executing step 5 of the transaction: 04000006 != 04000002
-    ┌─ examples/wishbone/wishbone.prot:408:9
+    ┌─ examples/wishbone/wishbone.prot:409:9
     │
-408 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
+409 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_4@25] executing step 5 of the transaction: 04000006 != 04000002
 
 
@@ -18,15 +18,15 @@ trace {
     reset(); [4]
 }
 error: [read_burst_increment_wrap_4@25L] executing step 5 of the transaction: 2 != 7
-    ┌─ examples/wishbone/wishbone.prot:412:13
+    ┌─ examples/wishbone/wishbone.prot:413:13
     │
-412 │             self.CTI := 3'b111;
+413 │             self.CTI := 3'b111;
     │             ^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_4@25L] executing step 5 of the transaction: 2 != 7
 
 error: [read_burst_increment_wrap_4@25L] executing step 5 of the transaction: 04000006 != 04000002
-    ┌─ examples/wishbone/wishbone.prot:408:9
+    ┌─ examples/wishbone/wishbone.prot:409:9
     │
-408 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
+409 │         self.ADR := start_addr[31:4] ## (start_addr[3:2] + iter_count::<u2>()) ## start_addr[1:0];
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [read_burst_increment_wrap_4@25L] executing step 5 of the transaction: 04000006 != 04000002
 
 ---CODE---

--- a/examples/wishbone/rtl/tb.v
+++ b/examples/wishbone/rtl/tb.v
@@ -18,6 +18,7 @@ module tb(
   input WE,
   input [3:0] SEL,
   output ERR,
+  output wire RTY,
   input [2:0] CTI,
   input wire [1:0] BTE
 );
@@ -35,6 +36,7 @@ wire [31:0] io_sram_datwr = 0;
 wire io_sram_we = 0;
 wire n_reset;
 assign n_reset = ~RST;
+assign RTY = 0;
 
   dut dut(
     .clk(clk),

--- a/examples/wishbone/wishbone.prot
+++ b/examples/wishbone/wishbone.prot
@@ -14,6 +14,8 @@ interface Wishbone {
     in DAT_O: u32,
     // error from server
     out ERR: u1,
+    // request to retry from server
+    out RTY: u1,
     // mask for data in/out from client
     in SEL: u4,
     // indicates a valid transfer cycle from client

--- a/examples/wishbone/wishbone.prot
+++ b/examples/wishbone/wishbone.prot
@@ -38,7 +38,6 @@ interface Wishbone {
     // 7: end of burst
     in CTI: u3,
     // no LOCK
-    // no RTY
 }
 
 prot reset<self: Wishbone>() {

--- a/protocols/src/dut.rs
+++ b/protocols/src/dut.rs
@@ -71,7 +71,11 @@ impl PatronusSim {
                         .inputs
                         .iter()
                         .position(|i| ctx.get_symbol_name(*i).unwrap() == pin.name())
-                        .context("unable to find input pin")?;
+                        .context(format!(
+                            "unable to find input pin `{}` in {}",
+                            pin.name(),
+                            sys.name
+                        ))?;
                     (sys.inputs[pos], pos)
                 }
                 Dir::Out => {
@@ -79,7 +83,11 @@ impl PatronusSim {
                         .outputs
                         .iter()
                         .position(|o| ctx[o.name] == pin.name())
-                        .context("unable to find output pin")?;
+                        .context(format!(
+                            "unable to find output pin `{}` in {}",
+                            pin.name(),
+                            sys.name
+                        ))?;
                     (sys.outputs[pos].expr, pos + sys.inputs.len())
                 }
             };

--- a/protocols/src/frontend/ast.rs
+++ b/protocols/src/frontend/ast.rs
@@ -161,6 +161,7 @@ pub struct RemapModule {
     pub clock: Clock,
     pub implements: Vec<StructId>,
     pub mappings: Vec<Mapping>,
+    pub consts: Vec<ConstMapping>,
 }
 
 #[cfg(test)]
@@ -174,11 +175,20 @@ pub(crate) fn assert_remap_eq(a: &RemapModule, b: &RemapModule) {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Mapping {
+    /// name of the pin in the module
     pub name: String,
+    /// direction of the pin in the module
     pub dir: Dir,
     pub tpe: Type,
     pub rhs: ExprId,
     pub cond: ExprId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConstMapping {
+    /// struct pin
+    pub pin: SymbolId,
+    pub value: BitVecValue,
 }
 
 #[derive(Debug, Clone)]

--- a/protocols/src/frontend/parser.rs
+++ b/protocols/src/frontend/parser.rs
@@ -192,7 +192,7 @@ fn boxed_expr_to_expr_id(
             expr_id
         }
         BoxedExpr::DontCare(start, end) => {
-            let expr_id = ctx.e(Expr::DontCare);
+            let expr_id = ctx.dont_care_id();
             ctx.add_expr_loc(expr_id, start, end, fileid);
             expr_id
         }

--- a/protocols/src/frontend/parser.rs
+++ b/protocols/src/frontend/parser.rs
@@ -62,6 +62,25 @@ fn expect_rule<T>(
     })
 }
 
+fn parse_integer_expr(pair: Pair) -> Result<BitVecValue, String> {
+    assert_eq!(pair.as_rule(), Rule::integer);
+    // unwrap into width, radix, and then value
+    let mut inner = pair.clone().into_inner();
+    let width: u32 = inner.next().unwrap().as_str().parse::<u32>().unwrap();
+    let radix = inner.next().unwrap().as_rule();
+    let value_str = inner.next().unwrap().as_str();
+
+    let value = match radix {
+        Rule::bin => u64::from_str_radix(value_str, 2),
+        Rule::oct => u64::from_str_radix(value_str, 8),
+        Rule::hex => u64::from_str_radix(value_str, 16),
+        Rule::dec => value_str.parse::<u64>(),
+        _ => unreachable!("Unexpected radix rule: {:?}", radix),
+    };
+
+    Ok(BitVecValue::from_u64(value.unwrap(), width))
+}
+
 fn parse_boxed_expr(
     st: &SymbolTable,
     diag: &mut DiagnosticHandler,
@@ -75,22 +94,7 @@ fn parse_boxed_expr(
 
             match primary.as_rule() {
                 Rule::integer => {
-                    // unwrap into width, radix, and then value
-                    let mut inner = primary.clone().into_inner();
-                    let width: u32 = inner.next().unwrap().as_str().parse::<u32>().unwrap();
-                    let radix = inner.next().unwrap().as_rule();
-                    let value_str = inner.next().unwrap().as_str();
-
-                    let value = match radix {
-                        Rule::bin => u64::from_str_radix(value_str, 2),
-                        Rule::oct => u64::from_str_radix(value_str, 8),
-                        Rule::hex => u64::from_str_radix(value_str, 16),
-                        Rule::dec => value_str.parse::<u64>(),
-                        _ => unreachable!("Unexpected radix rule: {:?}", radix),
-                    };
-
-                    let bvv = BitVecValue::from_u64(value.unwrap(), width);
-
+                    let bvv = parse_integer_expr(primary)?;
                     Ok(BoxedExpr::Const(bvv, start, end))
                 }
                 Rule::path_id => {
@@ -757,11 +761,6 @@ struct ModuleCtx<'a> {
 
 type Pair<'a> = pest::iterators::Pair<'a, Rule>;
 
-enum EntryTpe {
-    T(Type),
-    PosedgeClock,
-}
-
 impl ModuleCtx<'_> {
     // Helper method for expected rule errors
     fn expect_rule<T>(
@@ -796,6 +795,37 @@ impl ModuleCtx<'_> {
     }
 
     fn on_module_entry(&mut self, pair: Pair) -> Result<(), String> {
+        assert_eq!(pair.as_rule(), Rule::module_entry);
+        let entry = pair.into_inner().next().unwrap();
+        match entry.as_rule() {
+            Rule::clock_entry => self.on_clock_entry(entry),
+            Rule::remap_entry => self.on_remap_entry(entry),
+            Rule::const_entry => self.on_const_entry(entry),
+            other => todo!("Unexpected rule: {:?}", other),
+        }
+    }
+
+    fn on_clock_entry(&mut self, pair: Pair) -> Result<(), String> {
+        assert_eq!(pair.as_rule(), Rule::clock_entry);
+        let mut field_inner = pair.clone().into_inner();
+        let id_pair =
+            self.expect_rule(field_inner.next(), &pair, "Expected identifier in mapping")?;
+        let id = id_pair.as_str();
+        if matches!(self.m.clock, Clock::None) {
+            self.m.clock = Clock::Posedge(id.to_string());
+            Ok(())
+        } else {
+            let msg = format!(
+                "Module {} already has a clock declared: {:?}",
+                self.m.name, self.m.clock
+            );
+            self.err(msg, &pair)
+        }
+    }
+
+    fn on_remap_entry(&mut self, pair: Pair) -> Result<(), String> {
+        assert_eq!(pair.as_rule(), Rule::remap_entry);
+
         let mut field_inner = pair.clone().into_inner();
         let dir_pair =
             self.expect_rule(field_inner.next(), &pair, "Expected direction in mapping")?;
@@ -803,47 +833,14 @@ impl ModuleCtx<'_> {
             self.expect_rule(field_inner.next(), &pair, "Expected identifier in mapping")?;
         let tpe_pair = self.expect_rule(field_inner.next(), &pair, "Expected type in mapping")?;
         let dir = parse_dir(self.diag, self.fileid, dir_pair)?;
-        let id = id_pair.as_str();
-        let tpe = self.parse_entry_type(tpe_pair)?;
+        let name = id_pair.as_str().to_string();
+        let tpe = parse_type(self.diag, self.fileid, self.st, tpe_pair)?;
 
-        match tpe {
-            EntryTpe::T(tpe) => {
-                let remap_rule =
-                    self.expect_rule(field_inner.next(), &pair, "Pin remap expected.")?;
-                self.on_pin_remap(dir, id.into(), tpe, &pair, remap_rule)
-            }
-            EntryTpe::PosedgeClock => {
-                if matches!(self.m.clock, Clock::None) {
-                    if dir == Dir::In {
-                        self.m.clock = Clock::Posedge(id.to_string());
-                        Ok(())
-                    } else {
-                        let msg = "A clock must be an input, not an output".into();
-                        self.err(msg, &pair)
-                    }
-                } else {
-                    let msg = format!(
-                        "Module {} already has a clock declared: {:?}",
-                        self.m.name, self.m.clock
-                    );
-                    self.err(msg, &pair)
-                }
-            }
-        }
-    }
-
-    fn on_pin_remap(
-        &mut self,
-        dir: Dir,
-        name: String,
-        tpe: Type,
-        context: &Pair,
-        rule: Pair,
-    ) -> Result<(), String> {
-        assert_eq!(rule.as_rule(), Rule::pin_remap);
-        let mut in_remap = rule.into_inner();
-        let expr_rule =
-            self.expect_rule(in_remap.next(), context, "pin remaps require an expression")?;
+        let expr_rule = self.expect_rule(
+            field_inner.next(),
+            &pair,
+            "pin remaps require an expression",
+        )?;
         let rhs = parse_expr(
             self.st,
             self.diag,
@@ -851,7 +848,7 @@ impl ModuleCtx<'_> {
             &mut self.m.ctx,
             expr_rule.into_inner(),
         )?;
-        let cond = if let Some(cond_rule) = in_remap.next() {
+        let cond = if let Some(cond_rule) = field_inner.next() {
             parse_expr(
                 self.st,
                 self.diag,
@@ -873,24 +870,33 @@ impl ModuleCtx<'_> {
         Ok(())
     }
 
+    fn on_const_entry(&mut self, pair: Pair) -> Result<(), String> {
+        assert_eq!(pair.as_rule(), Rule::const_entry);
+        let mut field_inner = pair.clone().into_inner();
+        let id_pair =
+            self.expect_rule(field_inner.next(), &pair, "Expected identifier in mapping")?;
+        let expr_rule = self.expect_rule(
+            field_inner.next(),
+            &pair,
+            "const pins require an expression",
+        )?;
+        let path_id = id_pair.as_str();
+        let pin = self
+            .st
+            .symbol_id_from_name_in_active_scope(path_id)
+            .unwrap();
+
+        let value = parse_integer_expr(expr_rule)?;
+
+        let cc = ConstMapping { pin, value };
+        self.m.consts.push(cc);
+        Ok(())
+    }
+
     fn err(&mut self, msg: String, pair: &Pair) -> Result<(), String> {
         self.diag
             .emit_diagnostic_parsing(&msg, self.fileid, pair, Level::Error);
         Err(msg)
-    }
-
-    fn parse_entry_type(&mut self, pair: pest::iterators::Pair<Rule>) -> Result<EntryTpe, String> {
-        let pair = pair.into_inner().next().unwrap();
-        match pair.as_rule() {
-            Rule::clock_tpe => Ok(EntryTpe::PosedgeClock),
-            Rule::tpe => Ok(EntryTpe::T(parse_type(
-                self.diag,
-                self.fileid,
-                self.st,
-                pair,
-            )?)),
-            other => unreachable!("Unexpected rule: {:?}", other),
-        }
     }
 
     fn on_module_def(&mut self, pair: Pair) -> Result<(), String> {
@@ -1049,6 +1055,7 @@ fn parse_file_internal(
                     clock: Default::default(),
                     implements: vec![],
                     mappings: vec![],
+                    consts: vec![],
                 };
                 let mut ctx = ModuleCtx {
                     st,

--- a/protocols/src/frontend/protocols.pest
+++ b/protocols/src/frontend/protocols.pest
@@ -90,10 +90,11 @@ struct_def = { ("struct" | "interface") ~ path_id ~ "{" ~ field_list? ~ "}" }
 // modules
 module_impl_list = { (non_path_id ~ "+" ~ module_impl_list) | non_path_id }
 clock_tpe = { "clock" ~ "@posedge" }
-module_entry_tpe = { clock_tpe | tpe  }
+clock_entry = {"in" ~ path_id ~ ":" ~ "clock" ~ "@posedge" }
 pin_remap_constraint = {"with" ~ expr}
-pin_remap = { "=" ~ expr ~ pin_remap_constraint?}
-module_entry = {dir ~ path_id ~ ":" ~ module_entry_tpe ~ pin_remap? }
+remap_entry = {dir ~ path_id ~ ":" ~ tpe ~ "=" ~ expr ~ pin_remap_constraint?}
+const_entry = {"const" ~ path_id ~ "=" ~ integer }
+module_entry = { (clock_entry | remap_entry | const_entry) }
 module_entries = { (module_entry ~ "," ~ module_entries) | module_entry ~ ","? }
 module_def = { "module" ~ non_path_id ~ ":" ~ module_impl_list ~ "{" ~ module_entries ~ "}"}
 

--- a/protocols/src/frontend/remap.rs
+++ b/protocols/src/frontend/remap.rs
@@ -130,10 +130,9 @@ fn implement_remap(
                 .pins
                 .iter()
                 .zip(pin_syms.iter())
-                .map(|(field, sym)| {
+                .flat_map(|(field, sym)| {
                     let name = format!("{}.{}", orig_mod.name, field.name());
-                    let mapping = pin_to_remap[&name];
-                    (*sym, mapping)
+                    pin_to_remap.get(&name).map(|&mapping| (*sym, mapping))
                 })
                 .collect();
 

--- a/protocols/src/frontend/remap.rs
+++ b/protocols/src/frontend/remap.rs
@@ -6,7 +6,6 @@ use crate::frontend::ast::{
     Ast, BinOp, Clock, Expr, ExprId, Mapping, Protocol, ProtocolContext, RemapModule, Stmt, StmtId,
     find_symbols,
 };
-use crate::frontend::serialize::serialize_stmt;
 use crate::frontend::symbol::{Arg, Field, StructId, SymbolId, SymbolKind, SymbolTable, Type};
 use baa::BitVecValue;
 use rustc_hash::FxHashMap;

--- a/protocols/src/frontend/remap.rs
+++ b/protocols/src/frontend/remap.rs
@@ -321,14 +321,7 @@ impl Remapper<'_> {
                 } else if let Some(cc) = self.const_lookup.get(&lhs) {
                     // we are assigning to a pin that has a constant value => make sure that the assigned value matches
                     let e = self.out.e(Expr::Const(cc.clone()));
-
-                    let n = self.out.s(Stmt::AssertEq(e, rhs));
-                    println!(
-                        "replacing {} with {}",
-                        serialize_stmt(self.orig, self.st, &stmt),
-                        serialize_stmt(&self.out, self.st, &n)
-                    );
-                    n
+                    self.out.s(Stmt::AssertEq(e, rhs))
                 } else {
                     self.out.s(Stmt::Assign(lhs, rhs))
                 }

--- a/protocols/src/frontend/remap.rs
+++ b/protocols/src/frontend/remap.rs
@@ -6,7 +6,9 @@ use crate::frontend::ast::{
     Ast, BinOp, Clock, Expr, ExprId, Mapping, Protocol, ProtocolContext, RemapModule, Stmt, StmtId,
     find_symbols,
 };
+use crate::frontend::serialize::serialize_stmt;
 use crate::frontend::symbol::{Arg, Field, StructId, SymbolId, SymbolKind, SymbolTable, Type};
+use baa::BitVecValue;
 use rustc_hash::FxHashMap;
 
 /// Represents a DUT and associated protocols.
@@ -122,11 +124,20 @@ fn implement_remap(
         })
         .collect();
 
+    let pin_to_const: FxHashMap<_, _> = remap
+        .consts
+        .iter()
+        .map(|cc| {
+            let name = st[cc.pin].full_name(st);
+            (name, cc.value.clone())
+        })
+        .collect();
+
     for impl_struct_id in &remap.implements {
         let orig_mod = &originals[st[impl_struct_id].name()];
         for (proto, pin_syms) in orig_mod.protos.iter().zip(orig_mod.proto_pin_map.iter()) {
             // create mappings lookup
-            let lookup: FxHashMap<SymbolId, _> = orig_mod
+            let rename_lookup: FxHashMap<SymbolId, _> = orig_mod
                 .pins
                 .iter()
                 .zip(pin_syms.iter())
@@ -136,7 +147,24 @@ fn implement_remap(
                 })
                 .collect();
 
-            let remapped_proto = remap_proto(st, proto, remap_struct_id, &lookup, &remap.ctx);
+            let const_lookup: FxHashMap<SymbolId, _> = orig_mod
+                .pins
+                .iter()
+                .zip(pin_syms.iter())
+                .flat_map(|(field, sym)| {
+                    let name = format!("{}.{}", orig_mod.name, field.name());
+                    pin_to_const.get(&name).map(|value| (*sym, value.clone()))
+                })
+                .collect();
+
+            let remapped_proto = remap_proto(
+                st,
+                proto,
+                remap_struct_id,
+                &rename_lookup,
+                &const_lookup,
+                &remap.ctx,
+            );
             proto_pin_map.push(find_pin_mapping(st, &remap_pins, &remapped_proto));
             protos.push(remapped_proto);
         }
@@ -154,7 +182,8 @@ fn implement_remap(
 struct Remapper<'a> {
     st: &'a mut SymbolTable,
     orig: &'a Protocol,
-    lookup: &'a FxHashMap<SymbolId, (&'a Mapping, SymbolId)>,
+    rename_lookup: &'a FxHashMap<SymbolId, (&'a Mapping, SymbolId)>,
+    const_lookup: &'a FxHashMap<SymbolId, BitVecValue>,
     map_name_to_dut: FxHashMap<String, SymbolId>,
     remap_ctx: &'a ProtocolContext,
     out: Protocol,
@@ -164,17 +193,27 @@ fn remap_proto(
     st: &mut SymbolTable,
     orig: &Protocol,
     remap_struct_id: StructId,
-    lookup: &FxHashMap<SymbolId, (&Mapping, SymbolId)>,
+    rename_lookup: &FxHashMap<SymbolId, (&Mapping, SymbolId)>,
+    const_lookup: &FxHashMap<SymbolId, BitVecValue>,
     remap_ctx: &ProtocolContext,
 ) -> Protocol {
-    Remapper::new(st, orig, lookup, remap_struct_id, remap_ctx).run()
+    Remapper::new(
+        st,
+        orig,
+        rename_lookup,
+        const_lookup,
+        remap_struct_id,
+        remap_ctx,
+    )
+    .run()
 }
 
 impl<'a> Remapper<'a> {
     fn new(
         st: &'a mut SymbolTable,
         orig: &'a Protocol,
-        lookup: &'a FxHashMap<SymbolId, (&'a Mapping, SymbolId)>,
+        rename_lookup: &'a FxHashMap<SymbolId, (&'a Mapping, SymbolId)>,
+        const_lookup: &'a FxHashMap<SymbolId, BitVecValue>,
         remap_struct_id: StructId,
         remap_ctx: &'a ProtocolContext,
     ) -> Self {
@@ -222,7 +261,8 @@ impl<'a> Remapper<'a> {
             st,
             orig,
             out,
-            lookup,
+            rename_lookup,
+            const_lookup,
             map_name_to_dut,
             remap_ctx,
         }
@@ -245,17 +285,20 @@ impl Remapper<'_> {
             }
             Stmt::Assign(lhs, rhs) if rhs == self.orig.expr_dont_care() => {
                 let rhs = self.out.dont_care_id();
-                if let Some((m, _)) = self.lookup.get(&lhs) {
+                if let Some((m, _)) = self.rename_lookup.get(&lhs) {
                     let new_lhs = self.map_name_to_dut[&m.name];
                     // note: for DontCare assignments, we drop the condition
                     self.out.s(Stmt::Assign(new_lhs, rhs))
+                } else if self.const_lookup.contains_key(&lhs) {
+                    // remove assignment
+                    self.out.s(Stmt::Block(vec![]))
                 } else {
                     self.out.s(Stmt::Assign(lhs, rhs))
                 }
             }
             Stmt::Assign(lhs, rhs) => {
                 let rhs = self.on_expr(rhs);
-                if let Some((m, map_sym_id)) = self.lookup.get(&lhs) {
+                if let Some((m, map_sym_id)) = self.rename_lookup.get(&lhs) {
                     let new_lhs = self.map_name_to_dut[&m.name];
                     let new_rhs = self.on_remap_expr(*map_sym_id, rhs, m.rhs);
                     let new_assign = self.out.s(Stmt::Assign(new_lhs, new_rhs));
@@ -275,6 +318,17 @@ impl Remapper<'_> {
                     } else {
                         new_assign
                     }
+                } else if let Some(cc) = self.const_lookup.get(&lhs) {
+                    // we are assigning to a pin that has a constant value => make sure that the assigned value matches
+                    let e = self.out.e(Expr::Const(cc.clone()));
+
+                    let n = self.out.s(Stmt::AssertEq(e, rhs));
+                    println!(
+                        "replacing {} with {}",
+                        serialize_stmt(self.orig, self.st, &stmt),
+                        serialize_stmt(&self.out, self.st, &n)
+                    );
+                    n
                 } else {
                     self.out.s(Stmt::Assign(lhs, rhs))
                 }
@@ -328,37 +382,43 @@ impl Remapper<'_> {
         match self.orig[expr].clone() {
             Expr::Const(a) => self.out.e(Expr::Const(a)),
             Expr::Sym(sym_id) => {
-                match self.st[sym_id].kind() {
-                    SymbolKind::Dut => unreachable!(),
-                    SymbolKind::InPort => panic!("Did not expect to encounter an IN port!"),
-                    SymbolKind::OutPort => {
-                        let (m, _) = self.lookup[&sym_id];
-                        // output port mapping should always just be 1:1, this is enforced by the
-                        // frontend, but we want an assertion here to catch if that ever changes
-                        if let Expr::Sym(remap_rhs) = self.remap_ctx[m.rhs] {
-                            assert_eq!(self.st[remap_rhs].name(), self.st[sym_id].name());
-                            assert_eq!(self.st[remap_rhs].tpe(), self.st[sym_id].tpe());
-                        } else {
-                            unreachable!("Mapping must be 1:1");
+                if let Some(cc) = self.const_lookup.get(&sym_id) {
+                    self.out.e(Expr::Const(cc.clone()))
+                } else {
+                    match self.st[sym_id].kind() {
+                        SymbolKind::Dut => unreachable!(),
+                        SymbolKind::InPort => panic!("Did not expect to encounter an IN port!"),
+                        SymbolKind::OutPort => {
+                            let (m, _) = self.rename_lookup[&sym_id];
+                            // output port mapping should always just be 1:1, this is enforced by the
+                            // frontend, but we want an assertion here to catch if that ever changes
+                            if let Expr::Sym(remap_rhs) = self.remap_ctx[m.rhs] {
+                                assert_eq!(self.st[remap_rhs].name(), self.st[sym_id].name());
+                                assert_eq!(self.st[remap_rhs].tpe(), self.st[sym_id].tpe());
+                            } else {
+                                unreachable!("Mapping must be 1:1");
+                            }
+                            assert_eq!(m.cond, self.remap_ctx.expr_true());
+                            // lookup correct symbol
+                            let dut_name = self.st[self.out.dut_sym].name();
+                            let full_name = format!("{dut_name}.{}", m.name);
+                            let remapped_sym = self
+                                .st
+                                .symbol_id_from_name_in_active_scope(&full_name)
+                                .unwrap();
+                            self.out.e(Expr::Sym(remapped_sym))
                         }
-                        assert_eq!(m.cond, self.remap_ctx.expr_true());
-                        // lookup correct symbol
-                        let dut_name = self.st[self.out.dut_sym].name();
-                        let full_name = format!("{dut_name}.{}", m.name);
-                        let remapped_sym = self
-                            .st
-                            .symbol_id_from_name_in_active_scope(&full_name)
-                            .unwrap();
-                        self.out.e(Expr::Sym(remapped_sym))
-                    }
-                    SymbolKind::Arg(_) | SymbolKind::LoopVar => {
-                        // var should already be declared, just look up by name
-                        let name = self.st[sym_id].name();
-                        let out_sym = self
-                            .st
-                            .symbol_id_from_name_in_active_scope(name)
-                            .unwrap_or_else(|| unreachable!("{name} should have been declared!"));
-                        self.out.e(Expr::Sym(out_sym))
+                        SymbolKind::Arg(_) | SymbolKind::LoopVar => {
+                            // var should already be declared, just look up by name
+                            let name = self.st[sym_id].name();
+                            let out_sym = self
+                                .st
+                                .symbol_id_from_name_in_active_scope(name)
+                                .unwrap_or_else(|| {
+                                    unreachable!("{name} should have been declared!")
+                                });
+                            self.out.e(Expr::Sym(out_sym))
+                        }
                     }
                 }
             }

--- a/protocols/src/frontend/typecheck.rs
+++ b/protocols/src/frontend/typecheck.rs
@@ -12,6 +12,7 @@ use crate::frontend::static_checks::{check_assertion_wf, check_assignment_wf, ch
 use crate::frontend::symbol::*;
 use anyhow::{Context, anyhow, bail};
 use baa::BitVecOps;
+use rustc_hash::FxHashMap;
 
 /// Helper function for emitting error messages related to invalid bit-slices
 fn emit_bitslice_type_error(
@@ -359,7 +360,7 @@ fn is_input_map_rhs_ok(
     name: &str,
     rhs: ExprId,
     cond: ExprId,
-) -> bool {
+) -> Option<SymbolId> {
     let rhs_syms: Vec<_> = find_symbols(ctx, rhs).into_iter().collect();
     let cond_syms: Vec<_> = find_symbols(ctx, cond).into_iter().collect();
 
@@ -367,18 +368,18 @@ fn is_input_map_rhs_ok(
         && st[other].is_in_port()
     {
         if cond_syms.is_empty() || cond_syms == rhs_syms {
-            true
+            Some(other)
         } else {
             let msg = format!(
                 "The condition for the mapping of input pin `{name}` can only depend on the same pin as the mapping."
             );
             diag.emit_diagnostic_expr(ctx, &cond, &msg, Level::Error);
-            false
+            None
         }
     } else {
         let msg = format!("Input pin `{name}` must be mapped to a single other pin.");
         diag.emit_diagnostic_expr(ctx, &rhs, &msg, Level::Error);
-        false
+        None
     }
 }
 
@@ -390,21 +391,21 @@ fn is_output_map_rhs_ok(
     name: &str,
     rhs: ExprId,
     cond: ExprId,
-) -> bool {
+) -> Option<SymbolId> {
     if let Expr::Sym(sym_id) = ctx[rhs]
         && st[sym_id].is_out_port()
     {
         if cond == ctx.expr_true() {
-            true
+            Some(sym_id)
         } else {
             let msg = format!("Output pins are not allowed to have a `with` condition ({name}).");
             diag.emit_diagnostic_expr(ctx, &cond, &msg, Level::Error);
-            false
+            None
         }
     } else {
         let msg = format!("Output pin `{name}` can only be mapped directly to another output pin.");
         diag.emit_diagnostic_expr(ctx, &rhs, &msg, Level::Error);
-        false
+        None
     }
 }
 
@@ -425,9 +426,10 @@ pub(crate) fn type_check(ast: &mut Ast, diag: &mut DiagnosticHandler) -> anyhow:
         type_check_stmt(proto, &mut ast.st, diag, &proto.body)?;
     }
 
-    for remap in &ast.remaps {
+    for (remap_idx, remap) in ast.remaps.iter().enumerate() {
         let mut found_err = false;
         let ctx = &remap.ctx;
+        let mut interface_pin_to_mapping = FxHashMap::default();
         for m in &remap.mappings {
             // check that the rhs is of the correct type
             let rhs_tpe = type_check_expr(ctx, &ast.st, diag, &m.rhs)?;
@@ -456,12 +458,42 @@ pub(crate) fn type_check(ast: &mut Ast, diag: &mut DiagnosticHandler) -> anyhow:
                 found_err = true;
             }
 
-            let rhs_ok = match m.dir {
+            let rhs_symbol = match m.dir {
                 Dir::In => is_input_map_rhs_ok(ctx, &ast.st, diag, &m.name, m.rhs, m.cond),
                 Dir::Out => is_output_map_rhs_ok(ctx, &ast.st, diag, &m.name, m.rhs, m.cond),
             };
-            found_err |= !rhs_ok;
+            if let Some(rhs_symbol) = rhs_symbol {
+                interface_pin_to_mapping.insert(ast.st[rhs_symbol].full_name(&ast.st), remap_idx);
+            } else {
+                found_err = true;
+            }
         }
+
+        // check to see if there are any pins that we have not remapped
+        let missing_remaps: Vec<_> = remap
+            .implements
+            .iter()
+            .flat_map(|remap| {
+                ast.st[*remap].pins().iter().flat_map(|pin| {
+                    let full_name = format!("{}.{}", ast.st[*remap].name(), pin.name());
+                    if interface_pin_to_mapping.contains_key(&full_name) {
+                        None
+                    } else {
+                        Some(full_name)
+                    }
+                })
+            })
+            .collect();
+        if !missing_remaps.is_empty() {
+            let error_msg = format!(
+                "[{}] module does not define remaps for all pins. Missing: {}",
+                remap.name,
+                missing_remaps.join(", ")
+            );
+            diag.emit_general_message(&error_msg, Level::Error);
+            found_err = true;
+        }
+
         if found_err {
             bail!("Type error in {}", remap.name);
         }

--- a/protocols/src/frontend/typecheck.rs
+++ b/protocols/src/frontend/typecheck.rs
@@ -430,6 +430,7 @@ pub(crate) fn type_check(ast: &mut Ast, diag: &mut DiagnosticHandler) -> anyhow:
         let mut found_err = false;
         let ctx = &remap.ctx;
         let mut interface_pin_to_mapping = FxHashMap::default();
+        let mut interface_pin_to_const = FxHashMap::default();
         for m in &remap.mappings {
             // check that the rhs is of the correct type
             let rhs_tpe = type_check_expr(ctx, &ast.st, diag, &m.rhs)?;
@@ -469,6 +470,10 @@ pub(crate) fn type_check(ast: &mut Ast, diag: &mut DiagnosticHandler) -> anyhow:
             }
         }
 
+        for (cc_idx, cc) in remap.consts.iter().enumerate() {
+            interface_pin_to_const.insert(ast.st[cc.pin].full_name(&ast.st), cc_idx);
+        }
+
         // check to see if there are any pins that we have not remapped
         let missing_remaps: Vec<_> = remap
             .implements
@@ -476,7 +481,9 @@ pub(crate) fn type_check(ast: &mut Ast, diag: &mut DiagnosticHandler) -> anyhow:
             .flat_map(|remap| {
                 ast.st[*remap].pins().iter().flat_map(|pin| {
                     let full_name = format!("{}.{}", ast.st[*remap].name(), pin.name());
-                    if interface_pin_to_mapping.contains_key(&full_name) {
+                    if interface_pin_to_mapping.contains_key(&full_name)
+                        || interface_pin_to_const.contains_key(&full_name)
+                    {
                         None
                     } else {
                         Some(full_name)

--- a/protocols/src/frontend/typecheck.rs
+++ b/protocols/src/frontend/typecheck.rs
@@ -12,7 +12,7 @@ use crate::frontend::static_checks::{check_assertion_wf, check_assignment_wf, ch
 use crate::frontend::symbol::*;
 use anyhow::{Context, anyhow, bail};
 use baa::BitVecOps;
-use rustc_hash::FxHashMap;
+use rustc_hash::FxHashSet;
 
 /// Helper function for emitting error messages related to invalid bit-slices
 fn emit_bitslice_type_error(
@@ -426,11 +426,10 @@ pub(crate) fn type_check(ast: &mut Ast, diag: &mut DiagnosticHandler) -> anyhow:
         type_check_stmt(proto, &mut ast.st, diag, &proto.body)?;
     }
 
-    for (remap_idx, remap) in ast.remaps.iter().enumerate() {
+    for remap in &ast.remaps {
         let mut found_err = false;
         let ctx = &remap.ctx;
-        let mut interface_pin_to_mapping = FxHashMap::default();
-        let mut interface_pin_to_const = FxHashMap::default();
+        let mut defined_struct_pins = FxHashSet::default();
         for m in &remap.mappings {
             // check that the rhs is of the correct type
             let rhs_tpe = type_check_expr(ctx, &ast.st, diag, &m.rhs)?;
@@ -464,14 +463,25 @@ pub(crate) fn type_check(ast: &mut Ast, diag: &mut DiagnosticHandler) -> anyhow:
                 Dir::Out => is_output_map_rhs_ok(ctx, &ast.st, diag, &m.name, m.rhs, m.cond),
             };
             if let Some(rhs_symbol) = rhs_symbol {
-                interface_pin_to_mapping.insert(ast.st[rhs_symbol].full_name(&ast.st), remap_idx);
+                let full_name = ast.st[rhs_symbol].full_name(&ast.st);
+                if !defined_struct_pins.insert(full_name.clone()) {
+                    let error_msg =
+                        format!("Pin {full_name} has already been remapped in {}", m.name,);
+                    diag.emit_diagnostic_expr(&remap.ctx, &m.rhs, &error_msg, Level::Error);
+                    found_err = true;
+                };
             } else {
                 found_err = true;
             }
         }
 
-        for (cc_idx, cc) in remap.consts.iter().enumerate() {
-            interface_pin_to_const.insert(ast.st[cc.pin].full_name(&ast.st), cc_idx);
+        for cc in &remap.consts {
+            let full_name = ast.st[cc.pin].full_name(&ast.st);
+            if !defined_struct_pins.insert(full_name.clone()) {
+                let error_msg = format!("Pin {full_name} has already been remapped.",);
+                diag.emit_general_message(&error_msg, Level::Error);
+                found_err = true;
+            };
         }
 
         // check to see if there are any pins that we have not remapped
@@ -481,9 +491,7 @@ pub(crate) fn type_check(ast: &mut Ast, diag: &mut DiagnosticHandler) -> anyhow:
             .flat_map(|remap| {
                 ast.st[*remap].pins().iter().flat_map(|pin| {
                     let full_name = format!("{}.{}", ast.st[*remap].name(), pin.name());
-                    if interface_pin_to_mapping.contains_key(&full_name)
-                        || interface_pin_to_const.contains_key(&full_name)
-                    {
+                    if defined_struct_pins.contains(&full_name) {
                         None
                     } else {
                         Some(full_name)

--- a/protocols/src/tests/snapshots/protocols__frontend__serialize__tests__remap_module.snap
+++ b/protocols/src/tests/snapshots/protocols__frontend__serialize__tests__remap_module.snap
@@ -10,6 +10,7 @@ struct Wishbone {
   out DAT_I: u32,
   in DAT_O: u32,
   out ERR: u1,
+  out RTY: u1,
   in SEL: u4,
   in STB: u1,
   in WE: u1,


### PR DESCRIPTION
I am trying to get `ethmac` workin.

So far:

```
 ./target/release/bi -p examples/wishbone/wishbone.prot -p examples/wishbone/ethmac.prot --display-hex --show-waveform-time --wave ../protocols-evaluation/wishbone/ethmac/ethmac.fst --instances tb_ethernet.eth_top.wishbone:Tb_ethernetEth_topWishboneMWb

    reset();  // [time: 14708085ns -> 14708115ns]
}
error: [read_burst_increment_linear@534759] executing step 2 of the transaction: 00000801 != 00000800
    ┌─ examples/wishbone/wishbone.prot:331:9
    │
331 │         self.ADR := start_addr + (iter_count::<u30>() ## 2'b00);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [read_burst_increment_linear@534759] executing step 2 of the transaction: 00000801 != 00000800


```

```
./target/release/bi -p examples/wishbone/wishbone.prot -p examples/wishbone/ethmac.prot --display-hex --show-waveform-time --wave ../protocols-evaluation/wishbone/ethmac/ethmac.fst --instances tb_ethernet.eth_top:Tb_ethernetEth_topMWb

    reset();  // [time: 14708085ns -> 14708115ns]
}
error: [read_burst_increment_linear@534759] executing step 2 of the transaction: 00002004 != 00002000
    ┌─ examples/wishbone/wishbone.prot:331:9
    │
331 │         self.ADR := start_addr + (iter_count::<u30>() ## 2'b00);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [read_burst_increment_linear@534759] executing step 2 of the transaction: 00002004 != 00002000

```

For all the others I get:

```
./target/release/bi -p examples/wishbone/wishbone.prot -p examples/wishbone/ethmac.prot --display-hex --show-waveform-time --wave ../protocols-evaluation/wishbone/ethmac/ethmac.fst --instances tb_ethernet.wb_master.wbm_low_level:Tb_ethernetWb_masterWbm_low_level
thread 'main' (1554023) panicked at bi/src/bi.rs:789:44:
no entry found for key
stack backtrace:
   0: __rustc::rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::option::expect_failed
   3: bi::bi::BackwardsInterpreter::exec_step
   4: bi::run_bis
   5: bi::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```
